### PR TITLE
Create initial framework source-file skeleton for the multi-agent runtime

### DIFF
--- a/Tests/test_framework_imports.py
+++ b/Tests/test_framework_imports.py
@@ -68,5 +68,5 @@ def test_langgraph_compatible_run_populates_typed_graph() -> None:
     state = orchestrator.run_planned_stages()
 
     assert state.canonical_graph is not None
-    assert state.canonical_graph.system.name == "Threat Modeler Placeholder System"
+    assert state.canonical_graph.system.name == "Parsed System"
     assert state.messages[0]["stage_id"] == "agent_01"

--- a/Tests/test_framework_imports.py
+++ b/Tests/test_framework_imports.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+
+
+def test_framework_package_imports() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+    from threat_modeler import FrameworkOrchestrator, build_default_settings
+
+    orchestrator = FrameworkOrchestrator(build_default_settings())
+    assert orchestrator.planned_stage_ids() == [
+        "agent_01",
+        "agent_02",
+        "agent_03",
+        "agent_04",
+        "agent_05",
+        "agent_06",
+        "agent_07",
+        "agent_08",
+        "agent_09",
+    ]

--- a/Tests/test_framework_imports.py
+++ b/Tests/test_framework_imports.py
@@ -23,3 +23,50 @@ def test_framework_package_imports() -> None:
         "agent_08",
         "agent_09",
     ]
+
+
+def test_langgraph_compatible_execution_plan() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+    from threat_modeler import FrameworkOrchestrator, build_default_settings
+
+    settings = build_default_settings()
+    orchestrator = FrameworkOrchestrator(settings)
+    plan = orchestrator.build_langgraph_execution_plan()
+
+    assert plan.start_node_id == "agent_01"
+    assert plan.end_node_id == "agent_09"
+    assert len(plan.nodes) == 9
+    assert len(plan.edges) == 8
+
+
+def test_langgraph_compatible_run_populates_typed_graph() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+    from threat_modeler import FrameworkOrchestrator, build_default_settings
+
+    settings = build_default_settings()
+    settings = settings.__class__(
+        model=settings.model,
+        pipeline=settings.pipeline.__class__(
+            execution_mode="langgraph-compatible",
+            enabled_stage_ids=settings.pipeline.enabled_stage_ids,
+            stop_on_validation_error=settings.pipeline.stop_on_validation_error,
+            require_hitl_gates=settings.pipeline.require_hitl_gates,
+        ),
+    )
+
+    orchestrator = FrameworkOrchestrator(settings)
+    state = orchestrator.run_planned_stages()
+
+    assert state.canonical_graph is not None
+    assert state.canonical_graph.system.name == "Threat Modeler Placeholder System"
+    assert state.messages[0]["stage_id"] == "agent_01"

--- a/Tests/test_input_normalizer.py
+++ b/Tests/test_input_normalizer.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import sys
+
+
+def _ensure_src_on_path() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+
+def test_parser_normalize_raw_text_only_builds_typed_graph() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Vehicle Gateway\nHandles command routing\nECU_A -> ECU_B:CAN",
+            tables=[],
+        )
+    )
+
+    assert graph.system.name == "Vehicle Gateway"
+    assert graph.metadata.status == "parsed"
+    assert len(graph.components) >= 1
+    assert len(graph.data_flows) >= 1
+    assert graph.data_flows[0].id.startswith("df_")
+
+
+def test_parser_normalize_table_rows_maps_component_and_flow() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Control Plane",
+            tables=[
+                {
+                    "component": "Gateway Service",
+                    "parent_subsystem": "subsystem_core",
+                    "hardware": "vm",
+                    "software_modules": "router,auth",
+                    "description": "Ingress handler",
+                },
+                {
+                    "from_node": "gateway_service",
+                    "to_node": "policy_engine",
+                    "protocol": "https",
+                    "data_items": "jwt,request",
+                },
+            ],
+        )
+    )
+
+    component_names = [component.name for component in graph.components]
+    assert "Gateway Service" in component_names
+
+    table_flow = next(flow for flow in graph.data_flows if flow.from_node == "gateway_service")
+    assert table_flow.to_node == "policy_engine"
+    assert table_flow.protocol == "https"
+    assert table_flow.data_items == ["jwt", "request"]
+
+
+def test_agent01_populates_graph_from_state_input() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.agents.agent_01_input_normalizer import Agent01InputNormalizer
+    from threat_modeler.state import FrameworkState
+
+    agent = Agent01InputNormalizer()
+    state = FrameworkState(raw_text="Safety Controller\nHandles decisions", tables=[])
+
+    agent.run(state)
+
+    assert state.canonical_graph is not None
+    assert state.canonical_graph.system.name == "Safety Controller"

--- a/Tests/test_input_normalizer.py
+++ b/Tests/test_input_normalizer.py
@@ -23,7 +23,7 @@ def test_parser_normalize_raw_text_only_builds_typed_graph() -> None:
     )
 
     assert graph.system.name == "Vehicle Gateway"
-    assert graph.metadata.status == "parsed"
+    assert graph.metadata.model_level == "system"
     assert len(graph.components) >= 1
     assert len(graph.data_flows) >= 1
     assert graph.data_flows[0].id.startswith("df_")
@@ -78,3 +78,76 @@ def test_agent01_populates_graph_from_state_input() -> None:
 
     assert state.canonical_graph is not None
     assert state.canonical_graph.system.name == "Safety Controller"
+
+
+def test_parser_extracts_subsystems_from_structured_table_schema() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Mission Platform",
+            tables=[
+                {
+                    "schema": "subsystems",
+                    "rows": [
+                        {
+                            "subsystem": "Guidance",
+                            "subsystem_id": "subsystem_guidance",
+                            "description": "Trajectory and control decisions",
+                        }
+                    ],
+                }
+            ],
+        )
+    )
+
+    assert len(graph.subsystems) == 1
+    assert graph.subsystems[0].id == "subsystem_guidance"
+    assert graph.subsystems[0].name == "Guidance"
+
+
+def test_parser_extracts_richer_flows_from_structured_text_and_table() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text=(
+                "Flight Computer\n"
+                "Flow: from=gateway_api; to=policy_engine; protocol=https; data_items=jwt,request; trust_boundary=dmz"
+            ),
+            tables=[
+                {
+                    "schema": "flows",
+                    "rows": [
+                        {
+                            "from_node": "policy_engine",
+                            "to_node": "command_bus",
+                            "protocol": "can",
+                            "data_items": ["command"],
+                            "trust_boundary_name": "internal_control",
+                        }
+                    ],
+                }
+            ],
+        )
+    )
+
+    text_flow = next(flow for flow in graph.data_flows if flow.from_node == "gateway_api")
+    assert text_flow.to_node == "policy_engine"
+    assert text_flow.protocol == "https"
+    assert text_flow.data_items == ["jwt", "request"]
+    assert text_flow.trust_boundary_crossing is True
+    assert text_flow.trust_boundary_name == "dmz"
+
+    table_flow = next(flow for flow in graph.data_flows if flow.from_node == "policy_engine")
+    assert table_flow.to_node == "command_bus"
+    assert table_flow.protocol == "can"
+    assert table_flow.data_items == ["command"]
+    assert table_flow.trust_boundary_crossing is True
+    assert table_flow.trust_boundary_name == "internal_control"

--- a/Tests/test_parser_schema_coupling.py
+++ b/Tests/test_parser_schema_coupling.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+import sys
+
+
+def _ensure_src_on_path() -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+    return repo_root
+
+
+def _load_validator(repo_root: Path):
+    from jsonschema import Draft202012Validator
+
+    schema_path = repo_root / "docs" / "schemas" / "canonical_graph.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return Draft202012Validator(schema)
+
+
+def test_parser_output_from_text_is_schema_aligned() -> None:
+    repo_root = _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    validator = _load_validator(repo_root)
+    parser = ParserInterface()
+
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Command Processor\nFlow: from=client; to=gateway; protocol=https; data_items=token,request",
+            tables=[],
+        )
+    )
+
+    issues = list(validator.iter_errors(graph.to_dict()))
+    assert issues == []
+
+
+def test_parser_output_from_structured_tables_is_schema_aligned() -> None:
+    repo_root = _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    validator = _load_validator(repo_root)
+    parser = ParserInterface()
+
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Avionics Node",
+            tables=[
+                {
+                    "schema": "subsystems",
+                    "rows": [
+                        {
+                            "subsystem": "Control Plane",
+                            "subsystem_id": "subsystem_control_plane",
+                            "description": "Control and policy processing",
+                        }
+                    ],
+                },
+                {
+                    "schema": "components",
+                    "rows": [
+                        {
+                            "component": "Policy Engine",
+                            "component_id": "component_policy_engine",
+                            "parent_subsystem": "subsystem_control_plane",
+                            "hardware": "vm",
+                            "software_modules": ["policy", "rules"],
+                            "description": "Policy evaluation",
+                        }
+                    ],
+                },
+                {
+                    "schema": "flows",
+                    "rows": [
+                        {
+                            "from_node": "component_policy_engine",
+                            "to_node": "component_command_dispatch",
+                            "protocol": "grpc",
+                            "data_items": ["policy_decision"],
+                            "trust_boundary_name": "control_network",
+                        }
+                    ],
+                },
+            ],
+        )
+    )
+
+    issues = list(validator.iter_errors(graph.to_dict()))
+    assert issues == []

--- a/Tests/test_validation.py
+++ b/Tests/test_validation.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import sys
+
+
+def _add_src_to_path() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+
+def test_placeholder_graph_passes_schema_validation() -> None:
+    _add_src_to_path()
+
+    from threat_modeler.models import build_placeholder_graph
+    from threat_modeler.validation import CanonicalGraphValidator
+
+    validator = CanonicalGraphValidator()
+    result = validator.validate_graph(build_placeholder_graph())
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_missing_required_field_fails_schema_validation() -> None:
+    _add_src_to_path()
+
+    from threat_modeler.models import build_placeholder_graph
+    from threat_modeler.validation import CanonicalGraphValidator
+
+    graph_payload = build_placeholder_graph().to_dict()
+    del graph_payload["system"]["name"]
+
+    validator = CanonicalGraphValidator()
+    result = validator.validate_graph(graph_payload)
+
+    assert result.is_valid is False
+    assert result.issues[0].code == "SCHEMA_REQUIRED"
+    assert result.issues[0].location == "system"
+
+
+def test_additional_metadata_field_fails_schema_validation() -> None:
+    _add_src_to_path()
+
+    from threat_modeler.models import build_placeholder_graph
+    from threat_modeler.validation import CanonicalGraphValidator
+
+    graph_payload = build_placeholder_graph().to_dict()
+    graph_payload["metadata"]["status"] = "extra"
+
+    validator = CanonicalGraphValidator()
+    result = validator.validate_graph(graph_payload)
+
+    assert result.is_valid is False
+    assert result.issues[0].code == "SCHEMA_ADDITIONALPROPERTIES"
+    assert result.issues[0].location == "metadata"

--- a/planning/work_items/Issue_Framework_Source_Files.md
+++ b/planning/work_items/Issue_Framework_Source_Files.md
@@ -1,0 +1,90 @@
+# Issue Draft: Create Framework Source Files
+
+## Title
+
+Create initial framework source files for the multi-agent runtime skeleton
+
+## Problem Statement
+
+The repository has mature documentation, requirements, schemas, and process guidance, but it does not yet contain the first Python framework source files that represent the runtime architecture. This blocks early contract validation, test harness setup, and incremental implementation of the orchestrator and agents.
+
+## Goal
+
+Create an initial Python source skeleton under `src` that represents all major framework pieces known today while intentionally deferring deeper implementation details to future releases through explicit `TODO` markers.
+
+## Scope
+
+In scope:
+
+- Create the first Python package structure under `src`
+- Add runtime skeleton modules for orchestrator, state, agents, validation, HITL, exports, and configuration
+- Represent the known architecture components and boundaries documented in requirements and planning artifacts
+- Add typed interfaces, placeholders, and minimal docstrings where needed for readability
+- Add explicit `TODO` items for future implementation work that is intentionally deferred
+- Keep code importable and internally coherent even if behavior is stubbed
+
+Out of scope:
+
+- Full LangGraph workflow implementation
+- Real model-provider integration
+- Real retrieval integration
+- Full STIX generation
+- Production-grade persistence or UI work
+
+## Proposed Initial Source Areas
+
+- `src/threat_modeler/__init__.py`
+- `src/threat_modeler/config.py`
+- `src/threat_modeler/state.py`
+- `src/threat_modeler/orchestrator.py`
+- `src/threat_modeler/validation.py`
+- `src/threat_modeler/models/`
+- `src/threat_modeler/agents/`
+- `src/threat_modeler/hitl/`
+- `src/threat_modeler/exports/`
+- `src/threat_modeler/parsing/`
+
+## Acceptance Criteria
+
+- A Python package exists under `src` for the framework runtime skeleton.
+- The package structure represents the currently known architecture components.
+- Core modules for orchestrator, state, validation, configuration, parsing, HITL, agent interfaces, and exports exist.
+- Stub classes or functions exist for Agent 1 through Agent 9.
+- Source files include `TODO` markers for future-release work where implementation is intentionally deferred.
+- Imports between framework modules are coherent and support basic static inspection.
+- A short README update describes the initial source layout.
+- Initial tests or smoke checks are added for package importability where practical.
+
+## Requirement Linkage
+
+- PRJ-002
+- PRJ-003
+- PRJ-004
+- PRJ-005
+- PRJ-006
+- PRJ-008
+- PRJ-013
+- CMP-ORCH-001
+- CMP-ORCH-002
+- CMP-STATE-001
+- CMP-STATE-003
+
+## Verification Approach
+
+- Inspection of source layout against architecture and requirements
+- Import smoke test for package and top-level modules
+- Review of `TODO` markers for deferred work traceability
+
+## Risks and Notes
+
+- The skeleton should not pretend unfinished behavior exists; placeholders must fail clearly or raise `NotImplementedError` where appropriate.
+- `TODO` markers should be specific enough to support future issue breakdown.
+- The structure should be stable enough to support follow-on implementation branches without churn.
+
+## Definition of Done
+
+- Branch contains the initial framework source-file skeleton.
+- Code structure matches current architectural understanding.
+- Deferred work is marked clearly in code.
+- README and any directly affected docs are updated.
+- Markdownlint and relevant tests pass for the changed files.

--- a/planning/work_items/Issue_Parser_Normalization.md
+++ b/planning/work_items/Issue_Parser_Normalization.md
@@ -1,0 +1,76 @@
+# Issue Draft: Implement Parser Normalization to Canonical Graph
+
+## Title
+
+Implement parser normalization from raw inputs to typed canonical graph
+
+## Problem Statement
+
+The current parser seam in `src/threat_modeler/parsing/input_normalizer.py` returns a placeholder dictionary that does not produce a typed `CanonicalThreatModelGraph`. This blocks reliable stage-1 ingestion, weakens schema contract continuity, and prevents realistic end-to-end pipeline behavior.
+
+## Goal
+
+Implement parser normalization that converts `ParserInput` payloads into a schema-aligned typed `CanonicalThreatModelGraph` artifact suitable for Agent 1 output and downstream validation.
+
+## Scope
+
+In scope:
+
+- Implement normalization logic in `ParserInterface.normalize`
+- Return a typed canonical graph model (or strict schema-aligned payload mapped to the typed model)
+- Derive deterministic placeholder IDs where source IDs are missing
+- Map raw text and table input into initial canonical graph structures
+- Ensure produced artifacts are compatible with schema-backed validation
+- Add focused tests for parser normalization behavior
+
+Out of scope:
+
+- Advanced NLP extraction quality improvements
+- Retrieval integration for parser enrichment
+- Full confidence scoring and policy reasoning
+- HITL persistence changes
+
+## Primary Files Likely Affected
+
+- `src/threat_modeler/parsing/input_normalizer.py`
+- `src/threat_modeler/models/canonical.py`
+- `src/threat_modeler/agents/agent_01_input_normalizer.py`
+- `Tests/` parser-focused tests
+
+## Acceptance Criteria
+
+- Parser normalization produces canonical graph artifacts aligned with `docs/schemas/canonical_graph.schema.json`.
+- Output can be consumed by existing orchestrator and validation seams without compatibility hacks.
+- Deterministic IDs are generated for required entities when source data omits IDs.
+- Normalization supports both raw text-only and table-inclusive inputs.
+- Tests cover successful normalization and malformed input handling.
+
+## Requirement Linkage
+
+- PRJ-001
+- PRJ-002
+- PRJ-004
+- CMP-A01-001
+- CMP-A01-002
+- CMP-A01-003
+- INT-001
+- INT-002
+- INT-003
+
+## Verification Approach
+
+- Unit tests for parser input-to-canonical output mapping
+- Validation check against schema-backed validator
+- Inspection of generated IDs and required-field population
+
+## Risks and Notes
+
+- Parser output shape must stay aligned with schema-backed validation to avoid hidden contract drift.
+- Deterministic ID rules should be documented and stable for rerun consistency.
+- Scope should prioritize correctness and contract compliance over extraction sophistication.
+
+## Definition of Done
+
+- Parser normalization produces schema-aligned canonical artifacts.
+- Tests cover key normalization paths and error handling.
+- Integration with existing Agent 1 and validator seams remains stable.

--- a/planning/work_items/PR_Framework_Source_Files.md
+++ b/planning/work_items/PR_Framework_Source_Files.md
@@ -1,0 +1,70 @@
+# PR Draft: Create Initial Framework Source Files
+
+## Title
+
+Create initial framework source-file skeleton for the multi-agent runtime
+
+## Summary
+
+This pull request introduces the first Python framework source files under `src` for the threat-modeling runtime skeleton. The implementation is intentionally limited to the current known architecture and creates typed module boundaries, agent placeholders, orchestration scaffolding, and explicit `TODO` markers for future releases.
+
+## Linked Issue
+
+- Issue draft: `planning/work_items/Issue_Framework_Source_Files.md`
+
+## Requirements Addressed
+
+- PRJ-002
+- PRJ-003
+- PRJ-004
+- PRJ-005
+- PRJ-006
+- PRJ-008
+- PRJ-013
+- CMP-ORCH-001
+- CMP-ORCH-002
+- CMP-STATE-001
+- CMP-STATE-003
+
+## Scope of Change
+
+- Add initial Python package structure under `src`
+- Add framework modules for configuration, state, orchestration, validation, parsing, HITL, exports, and agent interfaces
+- Add placeholder implementations for Agent 1 through Agent 9
+- Add targeted README and documentation updates required to explain the new structure
+- Add minimal tests or smoke checks for importability where practical
+
+## Design Intent
+
+- Represent all major framework pieces known today
+- Keep boundaries explicit and typed where possible
+- Avoid fake completeness by using clear placeholders and `TODO` markers
+- Make the layout stable enough for future feature branches to fill in implementation details
+
+## Verification Evidence
+
+Planned verification:
+
+- Import smoke tests for top-level modules
+- Inspection against requirements and implementation plan
+- Markdownlint pass on changed markdown files
+
+Test results:
+
+- To be completed in implementation branch
+
+## Follow-Up Work Expected
+
+- Real LangGraph graph wiring
+- Canonical schema validation middleware
+- Real parser implementation
+- Retrieval adapters and evidence plumbing
+- STIX export implementation
+- HITL workflow persistence and audit logging
+
+## Reviewer Focus
+
+- Does the package structure reflect the architecture we know today?
+- Are deferred areas clearly identified rather than hidden?
+- Are module boundaries stable enough for parallel follow-on work?
+- Are requirement linkages and future seams clear?

--- a/src/README.md
+++ b/src/README.md
@@ -2,9 +2,25 @@
 
 This directory is the Python implementation root for runtime code.
 
-Planned modules:
+Current package scaffold:
 
-- core orchestration and state management
-- agent implementations and adapters
-- input parsing and normalization
-- export pipelines for STIX, diagrams, and reports
+- `threat_modeler/`
+- `threat_modeler/agents/`
+- `threat_modeler/models/`
+- `threat_modeler/parsing/`
+- `threat_modeler/hitl/`
+- `threat_modeler/exports/`
+
+Initial framework modules now include:
+
+- runtime configuration and pipeline settings
+- framework state container
+- linear orchestrator scaffold for known stages
+- placeholder validation seam
+- stub agent classes for Agent 1 through Agent 9
+- parsing, HITL, and export placeholders
+
+Implementation rule:
+
+- represent current architectural knowledge explicitly
+- defer incomplete behavior with targeted `TODO` markers rather than hiding future work

--- a/src/threat_modeler/__init__.py
+++ b/src/threat_modeler/__init__.py
@@ -1,0 +1,10 @@
+"""Top-level package for the threat modeler runtime skeleton."""
+
+from .config import RuntimeSettings, build_default_settings
+from .orchestrator import FrameworkOrchestrator
+
+__all__ = [
+    "FrameworkOrchestrator",
+    "RuntimeSettings",
+    "build_default_settings",
+]

--- a/src/threat_modeler/__init__.py
+++ b/src/threat_modeler/__init__.py
@@ -1,10 +1,13 @@
 """Top-level package for the threat modeler runtime skeleton."""
 
 from .config import RuntimeSettings, build_default_settings
+from .models import CanonicalThreatModelGraph, LangGraphExecutionPlan
 from .orchestrator import FrameworkOrchestrator
 
 __all__ = [
+    "CanonicalThreatModelGraph",
     "FrameworkOrchestrator",
+    "LangGraphExecutionPlan",
     "RuntimeSettings",
     "build_default_settings",
 ]

--- a/src/threat_modeler/agents/__init__.py
+++ b/src/threat_modeler/agents/__init__.py
@@ -1,0 +1,30 @@
+"""Agent registry for the initial framework skeleton."""
+
+from .agent_01_input_normalizer import Agent01InputNormalizer
+from .agent_02_context_builder import Agent02HierarchicalContextBuilder
+from .agent_03_trust_boundary import Agent03TrustBoundaryValidator
+from .agent_04_stride import Agent04StrideScorer
+from .agent_05_threats import Agent05ConcreteThreatGenerator
+from .agent_06_stix import Agent06StixPackager
+from .agent_07_mitigations import Agent07MitigationGenerator
+from .agent_08_diagrams import Agent08DiagramGenerator
+from .agent_09_report import Agent09HumanReportWriter
+from .base import FrameworkAgent
+
+
+def build_default_agents() -> dict[str, FrameworkAgent]:
+    agents: list[FrameworkAgent] = [
+        Agent01InputNormalizer(),
+        Agent02HierarchicalContextBuilder(),
+        Agent03TrustBoundaryValidator(),
+        Agent04StrideScorer(),
+        Agent05ConcreteThreatGenerator(),
+        Agent06StixPackager(),
+        Agent07MitigationGenerator(),
+        Agent08DiagramGenerator(),
+        Agent09HumanReportWriter(),
+    ]
+    return {agent.stage_id: agent for agent in agents}
+
+
+__all__ = ["FrameworkAgent", "build_default_agents"]

--- a/src/threat_modeler/agents/agent_01_input_normalizer.py
+++ b/src/threat_modeler/agents/agent_01_input_normalizer.py
@@ -1,4 +1,5 @@
 from .base import FrameworkAgent
+from ..models import build_placeholder_graph
 
 
 class Agent01InputNormalizer(FrameworkAgent):
@@ -10,5 +11,5 @@ class Agent01InputNormalizer(FrameworkAgent):
         )
 
     def _apply_placeholder_behavior(self, state):
-        if not state.canonical_graph:
-            state.canonical_graph = {"metadata": {"status": "placeholder"}, "data_flows": []}
+        if state.canonical_graph is None:
+            state.canonical_graph = build_placeholder_graph()

--- a/src/threat_modeler/agents/agent_01_input_normalizer.py
+++ b/src/threat_modeler/agents/agent_01_input_normalizer.py
@@ -1,5 +1,5 @@
 from .base import FrameworkAgent
-from ..models import build_placeholder_graph
+from ..parsing import ParserInput, ParserInterface
 
 
 class Agent01InputNormalizer(FrameworkAgent):
@@ -9,7 +9,9 @@ class Agent01InputNormalizer(FrameworkAgent):
             display_name="Input Normalizer and Graph Builder",
             next_stage_id="agent_02",
         )
+        self.parser = ParserInterface()
 
     def _apply_placeholder_behavior(self, state):
         if state.canonical_graph is None:
-            state.canonical_graph = build_placeholder_graph()
+            payload = ParserInput(raw_text=state.raw_text, tables=state.tables)
+            state.canonical_graph = self.parser.normalize(payload)

--- a/src/threat_modeler/agents/agent_01_input_normalizer.py
+++ b/src/threat_modeler/agents/agent_01_input_normalizer.py
@@ -1,0 +1,14 @@
+from .base import FrameworkAgent
+
+
+class Agent01InputNormalizer(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_01",
+            display_name="Input Normalizer and Graph Builder",
+            next_stage_id="agent_02",
+        )
+
+    def _apply_placeholder_behavior(self, state):
+        if not state.canonical_graph:
+            state.canonical_graph = {"metadata": {"status": "placeholder"}, "data_flows": []}

--- a/src/threat_modeler/agents/agent_02_context_builder.py
+++ b/src/threat_modeler/agents/agent_02_context_builder.py
@@ -1,0 +1,10 @@
+from .base import FrameworkAgent
+
+
+class Agent02HierarchicalContextBuilder(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_02",
+            display_name="Hierarchical Context Builder",
+            next_stage_id="agent_03",
+        )

--- a/src/threat_modeler/agents/agent_03_trust_boundary.py
+++ b/src/threat_modeler/agents/agent_03_trust_boundary.py
@@ -1,0 +1,13 @@
+from .base import FrameworkAgent
+
+
+class Agent03TrustBoundaryValidator(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_03",
+            display_name="Trust Boundary Validator",
+            next_stage_id="agent_04",
+        )
+
+    def _apply_placeholder_behavior(self, state):
+        state.trust_boundary_review_needed = True

--- a/src/threat_modeler/agents/agent_04_stride.py
+++ b/src/threat_modeler/agents/agent_04_stride.py
@@ -1,0 +1,13 @@
+from .base import FrameworkAgent
+
+
+class Agent04StrideScorer(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_04",
+            display_name="STRIDE Scorer",
+            next_stage_id="agent_05",
+        )
+
+    def _apply_placeholder_behavior(self, state):
+        state.stride_complete = True

--- a/src/threat_modeler/agents/agent_05_threats.py
+++ b/src/threat_modeler/agents/agent_05_threats.py
@@ -1,0 +1,13 @@
+from .base import FrameworkAgent
+
+
+class Agent05ConcreteThreatGenerator(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_05",
+            display_name="Concrete Threat Generator",
+            next_stage_id="agent_06",
+        )
+
+    def _apply_placeholder_behavior(self, state):
+        state.threats_generated = True

--- a/src/threat_modeler/agents/agent_06_stix.py
+++ b/src/threat_modeler/agents/agent_06_stix.py
@@ -1,0 +1,10 @@
+from .base import FrameworkAgent
+
+
+class Agent06StixPackager(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_06",
+            display_name="STIX Packager",
+            next_stage_id="agent_07",
+        )

--- a/src/threat_modeler/agents/agent_07_mitigations.py
+++ b/src/threat_modeler/agents/agent_07_mitigations.py
@@ -1,0 +1,10 @@
+from .base import FrameworkAgent
+
+
+class Agent07MitigationGenerator(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_07",
+            display_name="Mitigation Generator",
+            next_stage_id="agent_08",
+        )

--- a/src/threat_modeler/agents/agent_08_diagrams.py
+++ b/src/threat_modeler/agents/agent_08_diagrams.py
@@ -1,0 +1,10 @@
+from .base import FrameworkAgent
+
+
+class Agent08DiagramGenerator(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_08",
+            display_name="Diagram Generator",
+            next_stage_id="agent_09",
+        )

--- a/src/threat_modeler/agents/agent_09_report.py
+++ b/src/threat_modeler/agents/agent_09_report.py
@@ -1,0 +1,10 @@
+from .base import FrameworkAgent
+
+
+class Agent09HumanReportWriter(FrameworkAgent):
+    def __init__(self) -> None:
+        super().__init__(
+            stage_id="agent_09",
+            display_name="Human Report Writer",
+            next_stage_id=None,
+        )

--- a/src/threat_modeler/agents/base.py
+++ b/src/threat_modeler/agents/base.py
@@ -1,0 +1,22 @@
+"""Shared base class for staged agent placeholders."""
+
+from dataclasses import dataclass
+
+from ..state import FrameworkState
+
+
+@dataclass
+class FrameworkAgent:
+    stage_id: str
+    display_name: str
+    next_stage_id: str | None
+
+    def run(self, state: FrameworkState) -> FrameworkState:
+        state.record_message(self.stage_id, f"{self.display_name} placeholder executed.")
+        state.next_stage_id = self.next_stage_id
+        self._apply_placeholder_behavior(state)
+        return state
+
+    def _apply_placeholder_behavior(self, state: FrameworkState) -> None:
+        # TODO: Replace placeholder stage behavior with real runtime logic.
+        return None

--- a/src/threat_modeler/config.py
+++ b/src/threat_modeler/config.py
@@ -1,0 +1,46 @@
+"""Runtime configuration primitives for the framework skeleton."""
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class ModelSelection:
+    provider: str
+    model_name: str
+    offline_only: bool = True
+
+
+@dataclass(frozen=True)
+class PipelineSettings:
+    enabled_stage_ids: Sequence[str] = field(
+        default_factory=lambda: (
+            "agent_01",
+            "agent_02",
+            "agent_03",
+            "agent_04",
+            "agent_05",
+            "agent_06",
+            "agent_07",
+            "agent_08",
+            "agent_09",
+        )
+    )
+    stop_on_validation_error: bool = True
+    require_hitl_gates: bool = True
+
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    model: ModelSelection
+    pipeline: PipelineSettings = field(default_factory=PipelineSettings)
+
+
+def build_default_settings() -> RuntimeSettings:
+    return RuntimeSettings(
+        model=ModelSelection(
+            provider="unconfigured",
+            model_name="placeholder",
+            offline_only=True,
+        )
+    )

--- a/src/threat_modeler/config.py
+++ b/src/threat_modeler/config.py
@@ -13,6 +13,7 @@ class ModelSelection:
 
 @dataclass(frozen=True)
 class PipelineSettings:
+    execution_mode: str = "linear"
     enabled_stage_ids: Sequence[str] = field(
         default_factory=lambda: (
             "agent_01",

--- a/src/threat_modeler/exports/__init__.py
+++ b/src/threat_modeler/exports/__init__.py
@@ -1,0 +1,7 @@
+"""Export helpers for runtime outputs."""
+
+from .diagrams import DiagramExporter
+from .report import ReportExporter
+from .stix import StixExporter
+
+__all__ = ["DiagramExporter", "ReportExporter", "StixExporter"]

--- a/src/threat_modeler/exports/diagrams.py
+++ b/src/threat_modeler/exports/diagrams.py
@@ -2,6 +2,6 @@
 
 
 class DiagramExporter:
-    def export(self, canonical_graph: dict) -> dict[str, str]:
+    def export(self, canonical_graph) -> dict[str, str]:
         # TODO: Render deterministic Mermaid diagrams from canonical graph structure.
         return {"level_0": "flowchart TD\n    A[Placeholder]"}

--- a/src/threat_modeler/exports/diagrams.py
+++ b/src/threat_modeler/exports/diagrams.py
@@ -1,0 +1,7 @@
+"""Diagram export placeholder."""
+
+
+class DiagramExporter:
+    def export(self, canonical_graph: dict) -> dict[str, str]:
+        # TODO: Render deterministic Mermaid diagrams from canonical graph structure.
+        return {"level_0": "flowchart TD\n    A[Placeholder]"}

--- a/src/threat_modeler/exports/report.py
+++ b/src/threat_modeler/exports/report.py
@@ -2,6 +2,6 @@
 
 
 class ReportExporter:
-    def export(self, canonical_graph: dict) -> str:
+    def export(self, canonical_graph) -> str:
         # TODO: Produce the formal markdown report from approved artifacts.
         return "# Threat Model Report\n\nPlaceholder report for runtime skeleton."

--- a/src/threat_modeler/exports/report.py
+++ b/src/threat_modeler/exports/report.py
@@ -1,0 +1,7 @@
+"""Report export placeholder."""
+
+
+class ReportExporter:
+    def export(self, canonical_graph: dict) -> str:
+        # TODO: Produce the formal markdown report from approved artifacts.
+        return "# Threat Model Report\n\nPlaceholder report for runtime skeleton."

--- a/src/threat_modeler/exports/stix.py
+++ b/src/threat_modeler/exports/stix.py
@@ -1,0 +1,7 @@
+"""STIX export placeholder."""
+
+
+class StixExporter:
+    def export(self, canonical_graph: dict) -> dict:
+        # TODO: Convert approved threat-model artifacts into STIX 2.1 objects.
+        return {"type": "bundle", "objects": [], "source": canonical_graph.get("metadata", {})}

--- a/src/threat_modeler/exports/stix.py
+++ b/src/threat_modeler/exports/stix.py
@@ -2,6 +2,7 @@
 
 
 class StixExporter:
-    def export(self, canonical_graph: dict) -> dict:
+    def export(self, canonical_graph) -> dict:
         # TODO: Convert approved threat-model artifacts into STIX 2.1 objects.
-        return {"type": "bundle", "objects": [], "source": canonical_graph.get("metadata", {})}
+        graph_dict = canonical_graph.to_dict() if hasattr(canonical_graph, "to_dict") else canonical_graph
+        return {"type": "bundle", "objects": [], "source": graph_dict.get("metadata", {})}

--- a/src/threat_modeler/hitl/__init__.py
+++ b/src/threat_modeler/hitl/__init__.py
@@ -1,0 +1,5 @@
+"""Human-in-the-loop service entry points."""
+
+from .service import HitlDecision, HitlService
+
+__all__ = ["HitlDecision", "HitlService"]

--- a/src/threat_modeler/hitl/service.py
+++ b/src/threat_modeler/hitl/service.py
@@ -1,0 +1,24 @@
+"""HITL scaffolding for approval and override gates."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class HitlDecision:
+    action: str
+    rationale: str
+    actor: str
+    role: str
+
+
+class HitlService:
+    def requires_review(self, stage_id: str) -> bool:
+        return stage_id in {"agent_03", "agent_04", "agent_05", "agent_07", "agent_09"}
+
+    def record_decision(self, decision: HitlDecision) -> dict[str, str]:
+        # TODO: Persist signed gate decisions and audit diffs in a durable store.
+        return {
+            "action": decision.action,
+            "actor": decision.actor,
+            "role": decision.role,
+        }

--- a/src/threat_modeler/models/__init__.py
+++ b/src/threat_modeler/models/__init__.py
@@ -1,5 +1,15 @@
 """Shared data contracts for the framework skeleton."""
 
 from .artifacts import ExportArtifacts, ThreatModelArtifactSet
+from .canonical import CanonicalThreatModelGraph, build_placeholder_graph
+from .workflow import ExecutionEdge, ExecutionNode, LangGraphExecutionPlan
 
-__all__ = ["ExportArtifacts", "ThreatModelArtifactSet"]
+__all__ = [
+	"CanonicalThreatModelGraph",
+	"ExecutionEdge",
+	"ExecutionNode",
+	"ExportArtifacts",
+	"LangGraphExecutionPlan",
+	"ThreatModelArtifactSet",
+	"build_placeholder_graph",
+]

--- a/src/threat_modeler/models/__init__.py
+++ b/src/threat_modeler/models/__init__.py
@@ -1,0 +1,5 @@
+"""Shared data contracts for the framework skeleton."""
+
+from .artifacts import ExportArtifacts, ThreatModelArtifactSet
+
+__all__ = ["ExportArtifacts", "ThreatModelArtifactSet"]

--- a/src/threat_modeler/models/artifacts.py
+++ b/src/threat_modeler/models/artifacts.py
@@ -1,0 +1,17 @@
+"""Artifact grouping models used by the runtime skeleton."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ExportArtifacts:
+    stix_bundle: dict[str, Any] | None = None
+    mermaid_diagrams: dict[str, str] = field(default_factory=dict)
+    final_report: str | None = None
+
+
+@dataclass
+class ThreatModelArtifactSet:
+    canonical_graph: dict[str, Any] = field(default_factory=dict)
+    exports: ExportArtifacts = field(default_factory=ExportArtifacts)

--- a/src/threat_modeler/models/artifacts.py
+++ b/src/threat_modeler/models/artifacts.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+from .canonical import CanonicalThreatModelGraph
+
 
 @dataclass
 class ExportArtifacts:
@@ -13,5 +15,5 @@ class ExportArtifacts:
 
 @dataclass
 class ThreatModelArtifactSet:
-    canonical_graph: dict[str, Any] = field(default_factory=dict)
+    canonical_graph: CanonicalThreatModelGraph = field(default_factory=CanonicalThreatModelGraph)
     exports: ExportArtifacts = field(default_factory=ExportArtifacts)

--- a/src/threat_modeler/models/canonical.py
+++ b/src/threat_modeler/models/canonical.py
@@ -7,7 +7,6 @@ from dataclasses import asdict, dataclass, field
 class GraphMetadata:
     generation_timestamp: str = "placeholder"
     model_level: str = "system"
-    status: str = "placeholder"
 
 
 @dataclass

--- a/src/threat_modeler/models/canonical.py
+++ b/src/threat_modeler/models/canonical.py
@@ -1,0 +1,130 @@
+"""Typed canonical graph models for the framework skeleton."""
+
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class GraphMetadata:
+    generation_timestamp: str = "placeholder"
+    model_level: str = "system"
+    status: str = "placeholder"
+
+
+@dataclass
+class SystemContext:
+    name: str = "Threat Modeler Placeholder System"
+    description: str = "Initial framework skeleton canonical graph."
+    mission_criticality: str = "undetermined"
+    safety_criticality: str = "undetermined"
+
+
+@dataclass
+class Subsystem:
+    id: str
+    name: str
+    description: str
+    parent_system: str
+
+
+@dataclass
+class Component:
+    id: str
+    name: str
+    parent_subsystem: str
+    hardware: str
+    software_modules: list[str] = field(default_factory=list)
+    description: str = ""
+
+
+@dataclass
+class StrideAssessment:
+    S: int = 0
+    S_justification: str = "Not scored yet."
+    T: int = 0
+    T_justification: str = "Not scored yet."
+    R: int = 0
+    R_justification: str = "Not scored yet."
+    I: int = 0
+    I_justification: str = "Not scored yet."
+    D: int = 0
+    D_justification: str = "Not scored yet."
+    E: int = 0
+    E_justification: str = "Not scored yet."
+
+
+@dataclass
+class Mitigation:
+    control_id: str
+    title: str
+    description: str
+    residual_risk_after_control: int = 3
+
+
+@dataclass
+class Threat:
+    name: str
+    description: str
+    mitre_attack_technique: list[str] = field(default_factory=list)
+    capec_id: str = ""
+    cwe_id: str = ""
+    likelihood: int = 1
+    impact: int = 1
+    mitigations_technical: list[Mitigation] = field(default_factory=list)
+    mitigations_administrative: list[Mitigation] = field(default_factory=list)
+
+
+@dataclass
+class DataFlow:
+    id: str
+    from_node: str
+    to_node: str
+    protocol: str = "unknown"
+    data_items: list[str] = field(default_factory=list)
+    trust_boundary_crossing: bool = False
+    trust_boundary_name: str = ""
+    stride: StrideAssessment = field(default_factory=StrideAssessment)
+    threats: list[Threat] = field(default_factory=list)
+
+
+@dataclass
+class CanonicalThreatModelGraph:
+    metadata: GraphMetadata = field(default_factory=GraphMetadata)
+    system: SystemContext = field(default_factory=SystemContext)
+    subsystems: list[Subsystem] = field(default_factory=list)
+    components: list[Component] = field(default_factory=list)
+    data_flows: list[DataFlow] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def build_placeholder_graph() -> CanonicalThreatModelGraph:
+    return CanonicalThreatModelGraph(
+        subsystems=[
+            Subsystem(
+                id="subsystem_core",
+                name="Core Threat Modeling Pipeline",
+                description="Placeholder subsystem for the staged runtime.",
+                parent_system="Threat Modeler Placeholder System",
+            )
+        ],
+        components=[
+            Component(
+                id="component_orchestrator",
+                name="Framework Orchestrator",
+                parent_subsystem="subsystem_core",
+                hardware="host",
+                software_modules=["threat_modeler.orchestrator"],
+                description="Coordinates the staged execution skeleton.",
+            )
+        ],
+        data_flows=[
+            DataFlow(
+                id="df_placeholder_input",
+                from_node="user.input",
+                to_node="framework.orchestrator",
+                protocol="internal",
+                data_items=["raw_text", "tables"],
+            )
+        ],
+    )

--- a/src/threat_modeler/models/canonical.py
+++ b/src/threat_modeler/models/canonical.py
@@ -5,9 +5,8 @@ from dataclasses import asdict, dataclass, field
 
 @dataclass
 class GraphMetadata:
-    generation_timestamp: str = "placeholder"
+    generation_timestamp: str = "1970-01-01T00:00:00Z"
     model_level: str = "system"
-    status: str = "placeholder"
 
 
 @dataclass
@@ -96,6 +95,59 @@ class CanonicalThreatModelGraph:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "CanonicalThreatModelGraph":
+        metadata_payload = payload.get("metadata", {})
+        system_payload = payload.get("system", {})
+
+        subsystems = [Subsystem(**item) for item in payload.get("subsystems", [])]
+        components = [Component(**item) for item in payload.get("components", [])]
+
+        data_flows: list[DataFlow] = []
+        for item in payload.get("data_flows", []):
+            stride_payload = item.get("stride", {})
+            threats_payload = item.get("threats", [])
+
+            threats: list[Threat] = []
+            for threat_payload in threats_payload:
+                technical = [Mitigation(**entry) for entry in threat_payload.get("mitigations_technical", [])]
+                administrative = [Mitigation(**entry) for entry in threat_payload.get("mitigations_administrative", [])]
+                threats.append(
+                    Threat(
+                        name=threat_payload.get("name", ""),
+                        description=threat_payload.get("description", ""),
+                        mitre_attack_technique=threat_payload.get("mitre_attack_technique", []),
+                        capec_id=threat_payload.get("capec_id", ""),
+                        cwe_id=threat_payload.get("cwe_id", ""),
+                        likelihood=threat_payload.get("likelihood", 1),
+                        impact=threat_payload.get("impact", 1),
+                        mitigations_technical=technical,
+                        mitigations_administrative=administrative,
+                    )
+                )
+
+            data_flows.append(
+                DataFlow(
+                    id=item.get("id", ""),
+                    from_node=item.get("from_node", ""),
+                    to_node=item.get("to_node", ""),
+                    protocol=item.get("protocol", "unknown"),
+                    data_items=item.get("data_items", []),
+                    trust_boundary_crossing=item.get("trust_boundary_crossing", False),
+                    trust_boundary_name=item.get("trust_boundary_name", ""),
+                    stride=StrideAssessment(**stride_payload),
+                    threats=threats,
+                )
+            )
+
+        return cls(
+            metadata=GraphMetadata(**metadata_payload),
+            system=SystemContext(**system_payload),
+            subsystems=subsystems,
+            components=components,
+            data_flows=data_flows,
+        )
 
 
 def build_placeholder_graph() -> CanonicalThreatModelGraph:

--- a/src/threat_modeler/models/workflow.py
+++ b/src/threat_modeler/models/workflow.py
@@ -1,0 +1,23 @@
+"""Workflow and execution-plan models for LangGraph-compatible orchestration."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class ExecutionNode:
+    node_id: str
+    display_name: str
+
+
+@dataclass(frozen=True)
+class ExecutionEdge:
+    from_node_id: str
+    to_node_id: str
+
+
+@dataclass(frozen=True)
+class LangGraphExecutionPlan:
+    start_node_id: str | None
+    end_node_id: str | None
+    nodes: list[ExecutionNode] = field(default_factory=list)
+    edges: list[ExecutionEdge] = field(default_factory=list)

--- a/src/threat_modeler/orchestrator.py
+++ b/src/threat_modeler/orchestrator.py
@@ -1,0 +1,59 @@
+"""Stage orchestration skeleton for the threat modeler framework."""
+
+from dataclasses import dataclass
+
+from .agents import build_default_agents
+from .config import RuntimeSettings
+from .hitl import HitlService
+from .state import FrameworkState
+from .validation import CanonicalGraphValidator
+
+
+@dataclass
+class StageExecutionResult:
+    stage_id: str
+    success: bool
+
+
+class FrameworkOrchestrator:
+    def __init__(
+        self,
+        settings: RuntimeSettings,
+        *,
+        validator: CanonicalGraphValidator | None = None,
+        hitl_service: HitlService | None = None,
+    ) -> None:
+        self.settings = settings
+        self.validator = validator or CanonicalGraphValidator()
+        self.hitl_service = hitl_service or HitlService()
+        self.agents = build_default_agents()
+
+    def planned_stage_ids(self) -> list[str]:
+        return [stage_id for stage_id in self.settings.pipeline.enabled_stage_ids if stage_id in self.agents]
+
+    def initialize_state(self) -> FrameworkState:
+        state = FrameworkState()
+        stage_ids = self.planned_stage_ids()
+        state.next_stage_id = stage_ids[0] if stage_ids else None
+        return state
+
+    def run_stage(self, state: FrameworkState, stage_id: str) -> StageExecutionResult:
+        agent = self.agents[stage_id]
+        updated_state = agent.run(state)
+        state.next_stage_id = updated_state.next_stage_id
+        return StageExecutionResult(stage_id=stage_id, success=True)
+
+    def run_planned_stages(self, state: FrameworkState | None = None) -> FrameworkState:
+        active_state = state or self.initialize_state()
+
+        for index, stage_id in enumerate(self.planned_stage_ids()):
+            active_state.next_stage_id = stage_id
+            self.run_stage(active_state, stage_id)
+
+            if index > 0:
+                result = self.validator.validate(active_state)
+                if not result.is_valid and self.settings.pipeline.stop_on_validation_error:
+                    raise ValueError(result.issues[0].message)
+
+        # TODO: Replace linear execution with LangGraph routing and checkpointing.
+        return active_state

--- a/src/threat_modeler/orchestrator.py
+++ b/src/threat_modeler/orchestrator.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from .agents import build_default_agents
 from .config import RuntimeSettings
 from .hitl import HitlService
+from .models import ExecutionEdge, ExecutionNode, LangGraphExecutionPlan
 from .state import FrameworkState
 from .validation import CanonicalGraphValidator
 
@@ -37,6 +38,20 @@ class FrameworkOrchestrator:
         state.next_stage_id = stage_ids[0] if stage_ids else None
         return state
 
+    def build_langgraph_execution_plan(self) -> LangGraphExecutionPlan:
+        stage_ids = self.planned_stage_ids()
+        nodes = [ExecutionNode(node_id=stage_id, display_name=self.agents[stage_id].display_name) for stage_id in stage_ids]
+        edges = [
+            ExecutionEdge(from_node_id=stage_ids[index], to_node_id=stage_ids[index + 1])
+            for index in range(len(stage_ids) - 1)
+        ]
+        return LangGraphExecutionPlan(
+            start_node_id=stage_ids[0] if stage_ids else None,
+            end_node_id=stage_ids[-1] if stage_ids else None,
+            nodes=nodes,
+            edges=edges,
+        )
+
     def run_stage(self, state: FrameworkState, stage_id: str) -> StageExecutionResult:
         agent = self.agents[stage_id]
         updated_state = agent.run(state)
@@ -44,6 +59,9 @@ class FrameworkOrchestrator:
         return StageExecutionResult(stage_id=stage_id, success=True)
 
     def run_planned_stages(self, state: FrameworkState | None = None) -> FrameworkState:
+        if self.settings.pipeline.execution_mode == "langgraph-compatible":
+            return self.run_langgraph_compatible(state)
+
         active_state = state or self.initialize_state()
 
         for index, stage_id in enumerate(self.planned_stage_ids()):
@@ -56,4 +74,27 @@ class FrameworkOrchestrator:
                     raise ValueError(result.issues[0].message)
 
         # TODO: Replace linear execution with LangGraph routing and checkpointing.
+        return active_state
+
+    def run_langgraph_compatible(self, state: FrameworkState | None = None) -> FrameworkState:
+        active_state = state or self.initialize_state()
+        plan = self.build_langgraph_execution_plan()
+
+        if plan.start_node_id is None:
+            return active_state
+
+        current_stage_id = plan.start_node_id
+        edge_lookup = {edge.from_node_id: edge.to_node_id for edge in plan.edges}
+
+        while current_stage_id is not None:
+            active_state.next_stage_id = current_stage_id
+            self.run_stage(active_state, current_stage_id)
+
+            result = self.validator.validate(active_state)
+            if not result.is_valid and self.settings.pipeline.stop_on_validation_error:
+                raise ValueError(result.issues[0].message)
+
+            current_stage_id = edge_lookup.get(current_stage_id)
+
+        # TODO: Replace this compatibility layer with a real LangGraph StateGraph.
         return active_state

--- a/src/threat_modeler/parsing/__init__.py
+++ b/src/threat_modeler/parsing/__init__.py
@@ -1,0 +1,5 @@
+"""Input parsing seams for the framework skeleton."""
+
+from .input_normalizer import ParserInput, ParserInterface
+
+__all__ = ["ParserInput", "ParserInterface"]

--- a/src/threat_modeler/parsing/input_normalizer.py
+++ b/src/threat_modeler/parsing/input_normalizer.py
@@ -1,7 +1,17 @@
 """Parsing interfaces for architecture text and table inputs."""
 
 from dataclasses import dataclass, field
+import re
 from typing import Any
+
+from ..models.canonical import (
+    CanonicalThreatModelGraph,
+    Component,
+    DataFlow,
+    GraphMetadata,
+    Subsystem,
+    SystemContext,
+)
 
 
 @dataclass
@@ -11,10 +21,154 @@ class ParserInput:
 
 
 class ParserInterface:
-    def normalize(self, payload: ParserInput) -> dict[str, Any]:
-        # TODO: Parse architecture text and tables into canonical graph form.
-        return {
-            "metadata": {"status": "parsed_placeholder"},
-            "raw_text_present": bool(payload.raw_text),
-            "table_count": len(payload.tables),
-        }
+    def normalize(self, payload: ParserInput) -> CanonicalThreatModelGraph:
+        text_lines = [line.strip() for line in payload.raw_text.splitlines() if line.strip()]
+        system_name = text_lines[0] if text_lines else "Parsed System"
+        system_description = " ".join(text_lines[1:3]) if len(text_lines) > 1 else "Parsed from raw architecture input."
+
+        default_subsystem = Subsystem(
+            id="subsystem_core",
+            name="Core Subsystem",
+            description="Default subsystem created by parser normalization.",
+            parent_system=system_name,
+        )
+
+        components = self._components_from_tables(payload.tables)
+        if not components:
+            components = [
+                Component(
+                    id="component_primary",
+                    name="Primary Component",
+                    parent_subsystem=default_subsystem.id,
+                    hardware="unknown",
+                    software_modules=[],
+                    description="Default component created by parser normalization.",
+                )
+            ]
+
+        data_flows = self._flows_from_text(text_lines)
+        data_flows.extend(self._flows_from_tables(payload.tables))
+        if not data_flows:
+            data_flows = [
+                DataFlow(
+                    id="df_input_to_primary",
+                    from_node="user.input",
+                    to_node=components[0].id,
+                    protocol="internal",
+                    data_items=["raw_text", "tables"],
+                )
+            ]
+
+        return CanonicalThreatModelGraph(
+            metadata=GraphMetadata(status="parsed", model_level="system"),
+            system=SystemContext(
+                name=system_name,
+                description=system_description,
+                mission_criticality="undetermined",
+                safety_criticality="undetermined",
+            ),
+            subsystems=[default_subsystem],
+            components=components,
+            data_flows=data_flows,
+        )
+
+    def _components_from_tables(self, tables: list[dict[str, Any]]) -> list[Component]:
+        components: list[Component] = []
+        for index, row in enumerate(tables, start=1):
+            name = self._first_str(row, ["component", "component_name", "name"])
+            if not name:
+                continue
+
+            component_id = self._first_str(row, ["component_id", "id"]) or self._deterministic_id("component", name, index)
+            parent_subsystem = self._first_str(row, ["parent_subsystem", "subsystem_id"]) or "subsystem_core"
+            hardware = self._first_str(row, ["hardware", "platform"]) or "unknown"
+            description = self._first_str(row, ["description", "notes"]) or "Parsed from table input."
+            software_modules = self._extract_software_modules(row)
+
+            components.append(
+                Component(
+                    id=component_id,
+                    name=name,
+                    parent_subsystem=parent_subsystem,
+                    hardware=hardware,
+                    software_modules=software_modules,
+                    description=description,
+                )
+            )
+        return components
+
+    def _flows_from_text(self, text_lines: list[str]) -> list[DataFlow]:
+        flows: list[DataFlow] = []
+        pattern = re.compile(r"^(?P<from>[^-]+)->(?P<to>[^:]+)(?::(?P<protocol>.+))?$")
+        for index, line in enumerate(text_lines, start=1):
+            match = pattern.match(line.replace(" ", ""))
+            if not match:
+                continue
+
+            from_node = match.group("from")
+            to_node = match.group("to")
+            protocol = match.group("protocol") or "unknown"
+            flow_id = self._deterministic_id("df", f"{from_node}-{to_node}", index)
+            flows.append(
+                DataFlow(
+                    id=flow_id,
+                    from_node=from_node,
+                    to_node=to_node,
+                    protocol=protocol,
+                    data_items=["parsed_text"],
+                )
+            )
+        return flows
+
+    def _flows_from_tables(self, tables: list[dict[str, Any]]) -> list[DataFlow]:
+        flows: list[DataFlow] = []
+        for index, row in enumerate(tables, start=1):
+            from_node = self._first_str(row, ["from_node", "source", "from"])
+            to_node = self._first_str(row, ["to_node", "target", "to"])
+            if not from_node or not to_node:
+                continue
+
+            flow_id = self._first_str(row, ["flow_id", "id"]) or self._deterministic_id("df", f"{from_node}-{to_node}", index)
+            protocol = self._first_str(row, ["protocol", "transport"]) or "unknown"
+            data_items = self._split_list(self._first_str(row, ["data_items", "data", "payload"]))
+
+            flows.append(
+                DataFlow(
+                    id=flow_id,
+                    from_node=from_node,
+                    to_node=to_node,
+                    protocol=protocol,
+                    data_items=data_items,
+                )
+            )
+        return flows
+
+    @staticmethod
+    def _first_str(row: dict[str, Any], keys: list[str]) -> str:
+        for key in keys:
+            value = row.get(key)
+            if isinstance(value, str):
+                normalized = value.strip()
+                if normalized:
+                    return normalized
+        return ""
+
+    @staticmethod
+    def _split_list(value: str) -> list[str]:
+        if not value:
+            return []
+        return [part.strip() for part in value.split(",") if part.strip()]
+
+    def _extract_software_modules(self, row: dict[str, Any]) -> list[str]:
+        modules_value = row.get("software_modules") or row.get("software") or row.get("modules")
+        if isinstance(modules_value, list):
+            return [str(module).strip() for module in modules_value if str(module).strip()]
+        if isinstance(modules_value, str):
+            return self._split_list(modules_value)
+        return []
+
+    def _deterministic_id(self, prefix: str, source: str, index: int) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "_", source.lower()).strip("_")
+        if not slug:
+            slug = "item"
+        return f"{prefix}_{slug}_{index}"

--- a/src/threat_modeler/parsing/input_normalizer.py
+++ b/src/threat_modeler/parsing/input_normalizer.py
@@ -1,0 +1,20 @@
+"""Parsing interfaces for architecture text and table inputs."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class ParserInput:
+    raw_text: str = ""
+    tables: list[dict[str, Any]] = field(default_factory=list)
+
+
+class ParserInterface:
+    def normalize(self, payload: ParserInput) -> dict[str, Any]:
+        # TODO: Parse architecture text and tables into canonical graph form.
+        return {
+            "metadata": {"status": "parsed_placeholder"},
+            "raw_text_present": bool(payload.raw_text),
+            "table_count": len(payload.tables),
+        }

--- a/src/threat_modeler/parsing/input_normalizer.py
+++ b/src/threat_modeler/parsing/input_normalizer.py
@@ -25,21 +25,26 @@ class ParserInterface:
         text_lines = [line.strip() for line in payload.raw_text.splitlines() if line.strip()]
         system_name = text_lines[0] if text_lines else "Parsed System"
         system_description = " ".join(text_lines[1:3]) if len(text_lines) > 1 else "Parsed from raw architecture input."
+        normalized_rows = self._normalized_rows(payload.tables)
 
-        default_subsystem = Subsystem(
-            id="subsystem_core",
-            name="Core Subsystem",
-            description="Default subsystem created by parser normalization.",
-            parent_system=system_name,
-        )
+        subsystems = self._subsystems_from_tables(normalized_rows, system_name)
+        if not subsystems:
+            subsystems = [
+                Subsystem(
+                    id="subsystem_core",
+                    name="Core Subsystem",
+                    description="Default subsystem created by parser normalization.",
+                    parent_system=system_name,
+                )
+            ]
 
-        components = self._components_from_tables(payload.tables)
+        components = self._components_from_tables(normalized_rows, default_subsystem_id=subsystems[0].id)
         if not components:
             components = [
                 Component(
                     id="component_primary",
                     name="Primary Component",
-                    parent_subsystem=default_subsystem.id,
+                    parent_subsystem=subsystems[0].id,
                     hardware="unknown",
                     software_modules=[],
                     description="Default component created by parser normalization.",
@@ -47,7 +52,7 @@ class ParserInterface:
             ]
 
         data_flows = self._flows_from_text(text_lines)
-        data_flows.extend(self._flows_from_tables(payload.tables))
+        data_flows.extend(self._flows_from_tables(normalized_rows))
         if not data_flows:
             data_flows = [
                 DataFlow(
@@ -60,27 +65,65 @@ class ParserInterface:
             ]
 
         return CanonicalThreatModelGraph(
-            metadata=GraphMetadata(status="parsed", model_level="system"),
+            metadata=GraphMetadata(model_level="system"),
             system=SystemContext(
                 name=system_name,
                 description=system_description,
                 mission_criticality="undetermined",
                 safety_criticality="undetermined",
             ),
-            subsystems=[default_subsystem],
+            subsystems=subsystems,
             components=components,
             data_flows=data_flows,
         )
 
-    def _components_from_tables(self, tables: list[dict[str, Any]]) -> list[Component]:
-        components: list[Component] = []
+    def _subsystems_from_tables(self, tables: list[dict[str, Any]], system_name: str) -> list[Subsystem]:
+        subsystems: list[Subsystem] = []
+        seen_ids: set[str] = set()
+
         for index, row in enumerate(tables, start=1):
+            row_schema = self._row_schema(row)
+            if row_schema and row_schema not in {"subsystem", "subsystems"}:
+                continue
+
+            subsystem_name = self._first_str(row, ["subsystem", "subsystem_name", "name"])
+            if not subsystem_name:
+                continue
+
+            subsystem_id = self._first_str(row, ["subsystem_id", "id"]) or self._deterministic_id("subsystem", subsystem_name, index)
+            if subsystem_id in seen_ids:
+                continue
+
+            seen_ids.add(subsystem_id)
+            subsystems.append(
+                Subsystem(
+                    id=subsystem_id,
+                    name=subsystem_name,
+                    description=self._first_str(row, ["description", "notes"]) or "Parsed from table input.",
+                    parent_system=self._first_str(row, ["parent_system", "system"]) or system_name,
+                )
+            )
+
+        return subsystems
+
+    def _components_from_tables(self, tables: list[dict[str, Any]], *, default_subsystem_id: str) -> list[Component]:
+        components: list[Component] = []
+        seen_ids: set[str] = set()
+        for index, row in enumerate(tables, start=1):
+            row_schema = self._row_schema(row)
+            if row_schema and row_schema not in {"component", "components"}:
+                continue
+
             name = self._first_str(row, ["component", "component_name", "name"])
             if not name:
                 continue
 
             component_id = self._first_str(row, ["component_id", "id"]) or self._deterministic_id("component", name, index)
-            parent_subsystem = self._first_str(row, ["parent_subsystem", "subsystem_id"]) or "subsystem_core"
+            if component_id in seen_ids:
+                continue
+
+            seen_ids.add(component_id)
+            parent_subsystem = self._first_str(row, ["parent_subsystem", "subsystem_id"]) or default_subsystem_id
             hardware = self._first_str(row, ["hardware", "platform"]) or "unknown"
             description = self._first_str(row, ["description", "notes"]) or "Parsed from table input."
             software_modules = self._extract_software_modules(row)
@@ -99,38 +142,69 @@ class ParserInterface:
 
     def _flows_from_text(self, text_lines: list[str]) -> list[DataFlow]:
         flows: list[DataFlow] = []
-        pattern = re.compile(r"^(?P<from>[^-]+)->(?P<to>[^:]+)(?::(?P<protocol>.+))?$")
+        pattern = re.compile(r"^(?P<from>[^-]+)->(?P<to>[^:\[]+)(?::(?P<protocol>[^\[]+))?(?:\[(?P<data_items>[^\]]+)\])?$")
         for index, line in enumerate(text_lines, start=1):
-            match = pattern.match(line.replace(" ", ""))
-            if not match:
+            lower_line = line.lower()
+            if lower_line.startswith("flow:"):
+                fields = self._parse_structured_fields(line.split(":", maxsplit=1)[1])
+                from_node = fields.get("from") or fields.get("source")
+                to_node = fields.get("to") or fields.get("target")
+                if from_node and to_node:
+                    flow_id = fields.get("id") or self._deterministic_id("df", f"{from_node}-{to_node}", index)
+                    trust_boundary_name = fields.get("trust_boundary") or fields.get("boundary") or ""
+                    flows.append(
+                        DataFlow(
+                            id=flow_id,
+                            from_node=from_node,
+                            to_node=to_node,
+                            protocol=fields.get("protocol", "unknown"),
+                            data_items=self._split_list(fields.get("data_items") or fields.get("data") or ""),
+                            trust_boundary_crossing=bool(trust_boundary_name),
+                            trust_boundary_name=trust_boundary_name,
+                        )
+                    )
                 continue
 
-            from_node = match.group("from")
-            to_node = match.group("to")
-            protocol = match.group("protocol") or "unknown"
-            flow_id = self._deterministic_id("df", f"{from_node}-{to_node}", index)
-            flows.append(
-                DataFlow(
-                    id=flow_id,
-                    from_node=from_node,
-                    to_node=to_node,
-                    protocol=protocol,
-                    data_items=["parsed_text"],
+            compact = line.replace(" ", "")
+            match = pattern.match(compact)
+            if match:
+                from_node = match.group("from")
+                to_node = match.group("to")
+                protocol = match.group("protocol") or "unknown"
+                flow_id = self._deterministic_id("df", f"{from_node}-{to_node}", index)
+                items = self._split_list(match.group("data_items") or "") or ["parsed_text"]
+                flows.append(
+                    DataFlow(
+                        id=flow_id,
+                        from_node=from_node,
+                        to_node=to_node,
+                        protocol=protocol,
+                        data_items=items,
+                    )
                 )
-            )
         return flows
 
     def _flows_from_tables(self, tables: list[dict[str, Any]]) -> list[DataFlow]:
         flows: list[DataFlow] = []
+        seen_ids: set[str] = set()
         for index, row in enumerate(tables, start=1):
+            row_schema = self._row_schema(row)
+            if row_schema and row_schema not in {"flow", "flows", "data_flow", "data_flows"}:
+                continue
+
             from_node = self._first_str(row, ["from_node", "source", "from"])
             to_node = self._first_str(row, ["to_node", "target", "to"])
             if not from_node or not to_node:
                 continue
 
             flow_id = self._first_str(row, ["flow_id", "id"]) or self._deterministic_id("df", f"{from_node}-{to_node}", index)
+            if flow_id in seen_ids:
+                continue
+
+            seen_ids.add(flow_id)
             protocol = self._first_str(row, ["protocol", "transport"]) or "unknown"
-            data_items = self._split_list(self._first_str(row, ["data_items", "data", "payload"]))
+            data_items = self._extract_data_items(row)
+            trust_boundary_name = self._first_str(row, ["trust_boundary_name", "trust_boundary", "boundary"])
 
             flows.append(
                 DataFlow(
@@ -139,9 +213,50 @@ class ParserInterface:
                     to_node=to_node,
                     protocol=protocol,
                     data_items=data_items,
+                    trust_boundary_crossing=bool(trust_boundary_name),
+                    trust_boundary_name=trust_boundary_name,
                 )
             )
         return flows
+
+    def _normalized_rows(self, tables: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for table in tables:
+            nested_rows = table.get("rows")
+            if isinstance(nested_rows, list):
+                schema_name = self._first_str(table, ["schema", "kind", "type", "table"])
+                for nested_row in nested_rows:
+                    if not isinstance(nested_row, dict):
+                        continue
+                    enriched_row = dict(nested_row)
+                    if schema_name and "__schema" not in enriched_row:
+                        enriched_row["__schema"] = schema_name
+                    rows.append(enriched_row)
+                continue
+
+            rows.append(table)
+        return rows
+
+    def _row_schema(self, row: dict[str, Any]) -> str:
+        return self._first_str(row, ["__schema", "schema", "kind", "type"]).lower()
+
+    def _extract_data_items(self, row: dict[str, Any]) -> list[str]:
+        direct_list = row.get("data_items") or row.get("data") or row.get("payload")
+        if isinstance(direct_list, list):
+            return [str(item).strip() for item in direct_list if str(item).strip()]
+        return self._split_list(self._first_str(row, ["data_items", "data", "payload"]))
+
+    def _parse_structured_fields(self, text: str) -> dict[str, str]:
+        fields: dict[str, str] = {}
+        for part in text.split(";"):
+            if "=" not in part:
+                continue
+            key, value = part.split("=", maxsplit=1)
+            normalized_key = key.strip().lower()
+            normalized_value = value.strip()
+            if normalized_key and normalized_value:
+                fields[normalized_key] = normalized_value
+        return fields
 
     @staticmethod
     def _first_str(row: dict[str, Any], keys: list[str]) -> str:

--- a/src/threat_modeler/state.py
+++ b/src/threat_modeler/state.py
@@ -1,0 +1,23 @@
+"""Shared state container for staged framework execution."""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class FrameworkState:
+    raw_text: str = ""
+    tables: list[dict[str, Any]] = field(default_factory=list)
+    canonical_graph: dict[str, Any] = field(default_factory=dict)
+    messages: list[dict[str, Any]] = field(default_factory=list)
+    stix_bundle: dict[str, Any] | None = None
+    mermaid_diagrams: dict[str, str] = field(default_factory=dict)
+    final_report: str | None = None
+    human_feedback: str | None = None
+    next_stage_id: str | None = None
+    trust_boundary_review_needed: bool = False
+    stride_complete: bool = False
+    threats_generated: bool = False
+
+    def record_message(self, stage_id: str, text: str) -> None:
+        self.messages.append({"stage_id": stage_id, "text": text})

--- a/src/threat_modeler/state.py
+++ b/src/threat_modeler/state.py
@@ -3,12 +3,14 @@
 from dataclasses import dataclass, field
 from typing import Any
 
+from .models import CanonicalThreatModelGraph
+
 
 @dataclass
 class FrameworkState:
     raw_text: str = ""
     tables: list[dict[str, Any]] = field(default_factory=list)
-    canonical_graph: dict[str, Any] = field(default_factory=dict)
+    canonical_graph: CanonicalThreatModelGraph | None = None
     messages: list[dict[str, Any]] = field(default_factory=list)
     stix_bundle: dict[str, Any] | None = None
     mermaid_diagrams: dict[str, str] = field(default_factory=dict)
@@ -21,3 +23,8 @@ class FrameworkState:
 
     def record_message(self, stage_id: str, text: str) -> None:
         self.messages.append({"stage_id": stage_id, "text": text})
+
+    def canonical_graph_dict(self) -> dict[str, Any]:
+        if self.canonical_graph is None:
+            return {}
+        return self.canonical_graph.to_dict()

--- a/src/threat_modeler/validation.py
+++ b/src/threat_modeler/validation.py
@@ -1,6 +1,12 @@
 """Validation seams for the runtime skeleton."""
 
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import json
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 
 from .models import CanonicalThreatModelGraph
 from .state import FrameworkState
@@ -20,9 +26,19 @@ class ValidationResult:
 
 
 class CanonicalGraphValidator:
-    def validate(self, state: FrameworkState) -> ValidationResult:
-        graph = state.canonical_graph
+    def __init__(self, schema_path: Path | None = None) -> None:
+        self.schema_path = schema_path or self._default_schema_path()
+        self.schema = self._load_schema(self.schema_path)
+        self.validator = Draft202012Validator(self.schema)
 
+    def _default_schema_path(self) -> Path:
+        return Path(__file__).resolve().parents[2] / "docs" / "schemas" / "canonical_graph.schema.json"
+
+    def _load_schema(self, schema_path: Path) -> dict[str, Any]:
+        with schema_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def validate_graph(self, graph: CanonicalThreatModelGraph | dict[str, Any] | None) -> ValidationResult:
         if graph is None:
             return ValidationResult(
                 is_valid=False,
@@ -35,44 +51,33 @@ class CanonicalGraphValidator:
                 ],
             )
 
-        issues: list[ValidationIssue] = []
-
-        if not isinstance(graph, CanonicalThreatModelGraph):
-            issues.append(
-                ValidationIssue(
-                    code="CANONICAL_GRAPH_TYPE_INVALID",
-                    message="Canonical graph must use the typed canonical model.",
-                    location="canonical_graph",
-                )
-            )
+        if isinstance(graph, CanonicalThreatModelGraph):
+            graph_payload = graph.to_dict()
+        elif isinstance(graph, dict):
+            graph_payload = graph
         else:
-            if not graph.metadata.model_level:
-                issues.append(
+            return ValidationResult(
+                is_valid=False,
+                issues=[
                     ValidationIssue(
-                        code="MODEL_LEVEL_MISSING",
-                        message="Canonical graph metadata model level is required.",
-                        location="metadata.model_level",
+                        code="CANONICAL_GRAPH_TYPE_INVALID",
+                        message="Canonical graph must use the typed canonical model or a schema-shaped dictionary.",
+                        location="canonical_graph",
                     )
-                )
+                ],
+            )
 
-            if not graph.system.name:
-                issues.append(
-                    ValidationIssue(
-                        code="SYSTEM_NAME_MISSING",
-                        message="Canonical graph system name is required.",
-                        location="system.name",
-                    )
-                )
-
-            if graph.data_flows is None:
-                issues.append(
-                    ValidationIssue(
-                        code="DATA_FLOWS_MISSING",
-                        message="Canonical graph data flows collection is required.",
-                        location="data_flows",
-                    )
-                )
-
-        # TODO: Replace this placeholder with schema-backed validation against
-        # docs/schemas/canonical_graph.schema.json once model contracts are wired.
+        schema_errors = sorted(self.validator.iter_errors(graph_payload), key=lambda error: list(error.absolute_path))
+        issues = [self._issue_from_schema_error(error) for error in schema_errors]
         return ValidationResult(is_valid=not issues, issues=issues)
+
+    def validate(self, state: FrameworkState) -> ValidationResult:
+        return self.validate_graph(state.canonical_graph)
+
+    def _issue_from_schema_error(self, error: ValidationError) -> ValidationIssue:
+        location = ".".join(str(part) for part in error.absolute_path)
+        if not location:
+            location = "canonical_graph"
+
+        code = f"SCHEMA_{error.validator.upper()}"
+        return ValidationIssue(code=code, message=error.message, location=location)

--- a/src/threat_modeler/validation.py
+++ b/src/threat_modeler/validation.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 
+from .models import CanonicalThreatModelGraph
 from .state import FrameworkState
 
 
@@ -20,7 +21,9 @@ class ValidationResult:
 
 class CanonicalGraphValidator:
     def validate(self, state: FrameworkState) -> ValidationResult:
-        if not state.canonical_graph:
+        graph = state.canonical_graph
+
+        if graph is None:
             return ValidationResult(
                 is_valid=False,
                 issues=[
@@ -32,6 +35,44 @@ class CanonicalGraphValidator:
                 ],
             )
 
+        issues: list[ValidationIssue] = []
+
+        if not isinstance(graph, CanonicalThreatModelGraph):
+            issues.append(
+                ValidationIssue(
+                    code="CANONICAL_GRAPH_TYPE_INVALID",
+                    message="Canonical graph must use the typed canonical model.",
+                    location="canonical_graph",
+                )
+            )
+        else:
+            if not graph.metadata.model_level:
+                issues.append(
+                    ValidationIssue(
+                        code="MODEL_LEVEL_MISSING",
+                        message="Canonical graph metadata model level is required.",
+                        location="metadata.model_level",
+                    )
+                )
+
+            if not graph.system.name:
+                issues.append(
+                    ValidationIssue(
+                        code="SYSTEM_NAME_MISSING",
+                        message="Canonical graph system name is required.",
+                        location="system.name",
+                    )
+                )
+
+            if graph.data_flows is None:
+                issues.append(
+                    ValidationIssue(
+                        code="DATA_FLOWS_MISSING",
+                        message="Canonical graph data flows collection is required.",
+                        location="data_flows",
+                    )
+                )
+
         # TODO: Replace this placeholder with schema-backed validation against
         # docs/schemas/canonical_graph.schema.json once model contracts are wired.
-        return ValidationResult(is_valid=True)
+        return ValidationResult(is_valid=not issues, issues=issues)

--- a/src/threat_modeler/validation.py
+++ b/src/threat_modeler/validation.py
@@ -1,0 +1,37 @@
+"""Validation seams for the runtime skeleton."""
+
+from dataclasses import dataclass, field
+
+from .state import FrameworkState
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    code: str
+    message: str
+    location: str = ""
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    is_valid: bool
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+
+class CanonicalGraphValidator:
+    def validate(self, state: FrameworkState) -> ValidationResult:
+        if not state.canonical_graph:
+            return ValidationResult(
+                is_valid=False,
+                issues=[
+                    ValidationIssue(
+                        code="CANONICAL_GRAPH_MISSING",
+                        message="Canonical graph has not been produced yet.",
+                        location="canonical_graph",
+                    )
+                ],
+            )
+
+        # TODO: Replace this placeholder with schema-backed validation against
+        # docs/schemas/canonical_graph.schema.json once model contracts are wired.
+        return ValidationResult(is_valid=True)


### PR DESCRIPTION
## Summary

This pull request introduces the first Python framework source files under `src` for the threat-modeling runtime skeleton. The implementation now includes typed canonical graph models, stronger validation seams, agent placeholders, orchestration scaffolding, and a minimal LangGraph-compatible execution path with explicit `TODO` markers for future releases.

## Linked Issue

- Closes #2
- Source draft: `planning/work_items/Issue_Framework_Source_Files.md`

## Requirements Addressed

- PRJ-002
- PRJ-003
- PRJ-004
- PRJ-005
- PRJ-006
- PRJ-008
- PRJ-013
- CMP-ORCH-001
- CMP-ORCH-002
- CMP-STATE-001
- CMP-STATE-003

## Scope of Change

- Add initial Python package structure under `src`
- Add framework modules for configuration, state, orchestration, validation, parsing, HITL, exports, and agent interfaces
- Add placeholder implementations for Agent 1 through Agent 9
- Add typed canonical graph and workflow execution-plan models
- Add a minimal LangGraph-compatible execution path without taking a hard dependency on LangGraph yet
- Add targeted README and documentation updates required to explain the new structure
- Add minimal tests or smoke checks for importability and execution-plan behavior

## Design Intent

- Represent all major framework pieces known today
- Keep boundaries explicit and typed where possible
- Avoid fake completeness by using clear placeholders and `TODO` markers
- Make the layout stable enough for future feature branches to fill in implementation details
- Preserve a clean migration path from the current compatibility seam to a real LangGraph state graph

## Verification Evidence

- Import smoke test passed for `threat_modeler` package initialization and planned stage enumeration
- LangGraph-compatible execution plan generation returns 9 nodes and 8 edges
- LangGraph-compatible staged run executes successfully and produces a typed canonical graph placeholder

## Follow-Up Work Expected

- Real LangGraph graph wiring
- Canonical schema validation middleware against repository schema
- Real parser implementation
- Retrieval adapters and evidence plumbing
- STIX export implementation
- HITL workflow persistence and audit logging

## Reviewer Focus

- Does the package structure reflect the architecture we know today?
- Are deferred areas clearly identified rather than hidden?
- Are typed contracts and validation seams reasonable for follow-on implementation?
- Is the LangGraph-compatible path a sound transitional seam rather than accidental architecture drift?