### PR TITLE
Implement canonical graph schema-backed validation

### DIFF
--- a/Tests/test_validation.py
+++ b/Tests/test_validation.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import sys
+
+
+def _add_src_to_path() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+
+def test_placeholder_graph_passes_schema_validation() -> None:
+    _add_src_to_path()
+
+    from threat_modeler.models import build_placeholder_graph
+    from threat_modeler.validation import CanonicalGraphValidator
+
+    validator = CanonicalGraphValidator()
+    result = validator.validate_graph(build_placeholder_graph())
+
+    assert result.is_valid is True
+    assert result.issues == []
+
+
+def test_missing_required_field_fails_schema_validation() -> None:
+    _add_src_to_path()
+
+    from threat_modeler.models import build_placeholder_graph
+    from threat_modeler.validation import CanonicalGraphValidator
+
+    graph_payload = build_placeholder_graph().to_dict()
+    del graph_payload["system"]["name"]
+
+    validator = CanonicalGraphValidator()
+    result = validator.validate_graph(graph_payload)
+
+    assert result.is_valid is False
+    assert result.issues[0].code == "SCHEMA_REQUIRED"
+    assert result.issues[0].location == "system"
+
+
+def test_additional_metadata_field_fails_schema_validation() -> None:
+    _add_src_to_path()
+
+    from threat_modeler.models import build_placeholder_graph
+    from threat_modeler.validation import CanonicalGraphValidator
+
+    graph_payload = build_placeholder_graph().to_dict()
+    graph_payload["metadata"]["status"] = "extra"
+
+    validator = CanonicalGraphValidator()
+    result = validator.validate_graph(graph_payload)
+
+    assert result.is_valid is False
+    assert result.issues[0].code == "SCHEMA_ADDITIONALPROPERTIES"
+    assert result.issues[0].location == "metadata"

--- a/src/threat_modeler/models/canonical.py
+++ b/src/threat_modeler/models/canonical.py
@@ -5,9 +5,8 @@ from dataclasses import asdict, dataclass, field
 
 @dataclass
 class GraphMetadata:
-    generation_timestamp: str = "placeholder"
+    generation_timestamp: str = "1970-01-01T00:00:00Z"
     model_level: str = "system"
-    status: str = "placeholder"
 
 
 @dataclass
@@ -96,6 +95,59 @@ class CanonicalThreatModelGraph:
 
     def to_dict(self) -> dict:
         return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "CanonicalThreatModelGraph":
+        metadata_payload = payload.get("metadata", {})
+        system_payload = payload.get("system", {})
+
+        subsystems = [Subsystem(**item) for item in payload.get("subsystems", [])]
+        components = [Component(**item) for item in payload.get("components", [])]
+
+        data_flows: list[DataFlow] = []
+        for item in payload.get("data_flows", []):
+            stride_payload = item.get("stride", {})
+            threats_payload = item.get("threats", [])
+
+            threats: list[Threat] = []
+            for threat_payload in threats_payload:
+                technical = [Mitigation(**entry) for entry in threat_payload.get("mitigations_technical", [])]
+                administrative = [Mitigation(**entry) for entry in threat_payload.get("mitigations_administrative", [])]
+                threats.append(
+                    Threat(
+                        name=threat_payload.get("name", ""),
+                        description=threat_payload.get("description", ""),
+                        mitre_attack_technique=threat_payload.get("mitre_attack_technique", []),
+                        capec_id=threat_payload.get("capec_id", ""),
+                        cwe_id=threat_payload.get("cwe_id", ""),
+                        likelihood=threat_payload.get("likelihood", 1),
+                        impact=threat_payload.get("impact", 1),
+                        mitigations_technical=technical,
+                        mitigations_administrative=administrative,
+                    )
+                )
+
+            data_flows.append(
+                DataFlow(
+                    id=item.get("id", ""),
+                    from_node=item.get("from_node", ""),
+                    to_node=item.get("to_node", ""),
+                    protocol=item.get("protocol", "unknown"),
+                    data_items=item.get("data_items", []),
+                    trust_boundary_crossing=item.get("trust_boundary_crossing", False),
+                    trust_boundary_name=item.get("trust_boundary_name", ""),
+                    stride=StrideAssessment(**stride_payload),
+                    threats=threats,
+                )
+            )
+
+        return cls(
+            metadata=GraphMetadata(**metadata_payload),
+            system=SystemContext(**system_payload),
+            subsystems=subsystems,
+            components=components,
+            data_flows=data_flows,
+        )
 
 
 def build_placeholder_graph() -> CanonicalThreatModelGraph:

--- a/src/threat_modeler/validation.py
+++ b/src/threat_modeler/validation.py
@@ -1,6 +1,12 @@
 """Validation seams for the runtime skeleton."""
 
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import json
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError
 
 from .models import CanonicalThreatModelGraph
 from .state import FrameworkState
@@ -20,9 +26,19 @@ class ValidationResult:
 
 
 class CanonicalGraphValidator:
-    def validate(self, state: FrameworkState) -> ValidationResult:
-        graph = state.canonical_graph
+    def __init__(self, schema_path: Path | None = None) -> None:
+        self.schema_path = schema_path or self._default_schema_path()
+        self.schema = self._load_schema(self.schema_path)
+        self.validator = Draft202012Validator(self.schema)
 
+    def _default_schema_path(self) -> Path:
+        return Path(__file__).resolve().parents[2] / "docs" / "schemas" / "canonical_graph.schema.json"
+
+    def _load_schema(self, schema_path: Path) -> dict[str, Any]:
+        with schema_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def validate_graph(self, graph: CanonicalThreatModelGraph | dict[str, Any] | None) -> ValidationResult:
         if graph is None:
             return ValidationResult(
                 is_valid=False,
@@ -35,44 +51,33 @@ class CanonicalGraphValidator:
                 ],
             )
 
-        issues: list[ValidationIssue] = []
-
-        if not isinstance(graph, CanonicalThreatModelGraph):
-            issues.append(
-                ValidationIssue(
-                    code="CANONICAL_GRAPH_TYPE_INVALID",
-                    message="Canonical graph must use the typed canonical model.",
-                    location="canonical_graph",
-                )
-            )
+        if isinstance(graph, CanonicalThreatModelGraph):
+            graph_payload = graph.to_dict()
+        elif isinstance(graph, dict):
+            graph_payload = graph
         else:
-            if not graph.metadata.model_level:
-                issues.append(
+            return ValidationResult(
+                is_valid=False,
+                issues=[
                     ValidationIssue(
-                        code="MODEL_LEVEL_MISSING",
-                        message="Canonical graph metadata model level is required.",
-                        location="metadata.model_level",
+                        code="CANONICAL_GRAPH_TYPE_INVALID",
+                        message="Canonical graph must use the typed canonical model or a schema-shaped dictionary.",
+                        location="canonical_graph",
                     )
-                )
+                ],
+            )
 
-            if not graph.system.name:
-                issues.append(
-                    ValidationIssue(
-                        code="SYSTEM_NAME_MISSING",
-                        message="Canonical graph system name is required.",
-                        location="system.name",
-                    )
-                )
-
-            if graph.data_flows is None:
-                issues.append(
-                    ValidationIssue(
-                        code="DATA_FLOWS_MISSING",
-                        message="Canonical graph data flows collection is required.",
-                        location="data_flows",
-                    )
-                )
-
-        # TODO: Replace this placeholder with schema-backed validation against
-        # docs/schemas/canonical_graph.schema.json once model contracts are wired.
+        schema_errors = sorted(self.validator.iter_errors(graph_payload), key=lambda error: list(error.absolute_path))
+        issues = [self._issue_from_schema_error(error) for error in schema_errors]
         return ValidationResult(is_valid=not issues, issues=issues)
+
+    def validate(self, state: FrameworkState) -> ValidationResult:
+        return self.validate_graph(state.canonical_graph)
+
+    def _issue_from_schema_error(self, error: ValidationError) -> ValidationIssue:
+        location = ".".join(str(part) for part in error.absolute_path)
+        if not location:
+            location = "canonical_graph"
+
+        code = f"SCHEMA_{error.validator.upper()}"
+        return ValidationIssue(code=code, message=error.message, location=location)


### PR DESCRIPTION
## Summary

This pull request replaces the placeholder canonical graph validation seam with real schema-backed validation against `docs/schemas/canonical_graph.schema.json`. It also aligns the typed canonical graph model with the authoritative schema and adds focused tests for valid and invalid graph cases.

## Linked Issue

- Closes #3

## Requirements Addressed

- PRJ-002
- PRJ-003
- PRJ-004
- PRJ-015
- CMP-STATE-003
- INT-004

## Scope of Change

- Load the authoritative canonical graph schema from the repository
- Validate typed canonical graph instances and schema-shaped dictionaries against that schema
- Return structured validation issues with machine-readable codes, messages, and locations
- Align the typed canonical graph placeholder model with the authoritative schema
- Add tests for valid and invalid canonical graph validation cases

## Verification Evidence

- Placeholder graph validation passes with zero issues
- Invalid graph payload with a missing required field fails with `SCHEMA_REQUIRED`
- Validation issue location reporting resolves to the affected schema path
- The existing scaffold execution path continues to run successfully with valid placeholder data

## Reviewer Focus

- Does the validator enforce the repository schema rather than an ad hoc contract?
- Are validation issue codes and locations useful enough for downstream orchestration and debugging?
- Does the typed canonical model now align with the authoritative schema without hidden drift?
- Is the stacked PR target correct given the dependency on PR #1?
