### PR TITLE
feat(parser): normalize inputs to typed canonical graph (slice 1 + slice 2)

### DIFF
--- a/Tests/test_framework_imports.py
+++ b/Tests/test_framework_imports.py
@@ -68,5 +68,5 @@ def test_langgraph_compatible_run_populates_typed_graph() -> None:
     state = orchestrator.run_planned_stages()
 
     assert state.canonical_graph is not None
-    assert state.canonical_graph.system.name == "Threat Modeler Placeholder System"
+    assert state.canonical_graph.system.name == "Parsed System"
     assert state.messages[0]["stage_id"] == "agent_01"

--- a/Tests/test_input_normalizer.py
+++ b/Tests/test_input_normalizer.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import sys
+
+
+def _ensure_src_on_path() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+
+def test_parser_normalize_raw_text_only_builds_typed_graph() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Vehicle Gateway\nHandles command routing\nECU_A -> ECU_B:CAN",
+            tables=[],
+        )
+    )
+
+    assert graph.system.name == "Vehicle Gateway"
+    assert graph.metadata.status == "parsed"
+    assert len(graph.components) >= 1
+    assert len(graph.data_flows) >= 1
+    assert graph.data_flows[0].id.startswith("df_")
+
+
+def test_parser_normalize_table_rows_maps_component_and_flow() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Control Plane",
+            tables=[
+                {
+                    "component": "Gateway Service",
+                    "parent_subsystem": "subsystem_core",
+                    "hardware": "vm",
+                    "software_modules": "router,auth",
+                    "description": "Ingress handler",
+                },
+                {
+                    "from_node": "gateway_service",
+                    "to_node": "policy_engine",
+                    "protocol": "https",
+                    "data_items": "jwt,request",
+                },
+            ],
+        )
+    )
+
+    component_names = [component.name for component in graph.components]
+    assert "Gateway Service" in component_names
+
+    table_flow = next(flow for flow in graph.data_flows if flow.from_node == "gateway_service")
+    assert table_flow.to_node == "policy_engine"
+    assert table_flow.protocol == "https"
+    assert table_flow.data_items == ["jwt", "request"]
+
+
+def test_agent01_populates_graph_from_state_input() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.agents.agent_01_input_normalizer import Agent01InputNormalizer
+    from threat_modeler.state import FrameworkState
+
+    agent = Agent01InputNormalizer()
+    state = FrameworkState(raw_text="Safety Controller\nHandles decisions", tables=[])
+
+    agent.run(state)
+
+    assert state.canonical_graph is not None
+    assert state.canonical_graph.system.name == "Safety Controller"

--- a/Tests/test_input_normalizer.py
+++ b/Tests/test_input_normalizer.py
@@ -23,7 +23,7 @@ def test_parser_normalize_raw_text_only_builds_typed_graph() -> None:
     )
 
     assert graph.system.name == "Vehicle Gateway"
-    assert graph.metadata.status == "parsed"
+    assert graph.metadata.model_level == "system"
     assert len(graph.components) >= 1
     assert len(graph.data_flows) >= 1
     assert graph.data_flows[0].id.startswith("df_")
@@ -78,3 +78,76 @@ def test_agent01_populates_graph_from_state_input() -> None:
 
     assert state.canonical_graph is not None
     assert state.canonical_graph.system.name == "Safety Controller"
+
+
+def test_parser_extracts_subsystems_from_structured_table_schema() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Mission Platform",
+            tables=[
+                {
+                    "schema": "subsystems",
+                    "rows": [
+                        {
+                            "subsystem": "Guidance",
+                            "subsystem_id": "subsystem_guidance",
+                            "description": "Trajectory and control decisions",
+                        }
+                    ],
+                }
+            ],
+        )
+    )
+
+    assert len(graph.subsystems) == 1
+    assert graph.subsystems[0].id == "subsystem_guidance"
+    assert graph.subsystems[0].name == "Guidance"
+
+
+def test_parser_extracts_richer_flows_from_structured_text_and_table() -> None:
+    _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    parser = ParserInterface()
+    graph = parser.normalize(
+        ParserInput(
+            raw_text=(
+                "Flight Computer\n"
+                "Flow: from=gateway_api; to=policy_engine; protocol=https; data_items=jwt,request; trust_boundary=dmz"
+            ),
+            tables=[
+                {
+                    "schema": "flows",
+                    "rows": [
+                        {
+                            "from_node": "policy_engine",
+                            "to_node": "command_bus",
+                            "protocol": "can",
+                            "data_items": ["command"],
+                            "trust_boundary_name": "internal_control",
+                        }
+                    ],
+                }
+            ],
+        )
+    )
+
+    text_flow = next(flow for flow in graph.data_flows if flow.from_node == "gateway_api")
+    assert text_flow.to_node == "policy_engine"
+    assert text_flow.protocol == "https"
+    assert text_flow.data_items == ["jwt", "request"]
+    assert text_flow.trust_boundary_crossing is True
+    assert text_flow.trust_boundary_name == "dmz"
+
+    table_flow = next(flow for flow in graph.data_flows if flow.from_node == "policy_engine")
+    assert table_flow.to_node == "command_bus"
+    assert table_flow.protocol == "can"
+    assert table_flow.data_items == ["command"]
+    assert table_flow.trust_boundary_crossing is True
+    assert table_flow.trust_boundary_name == "internal_control"

--- a/Tests/test_parser_schema_coupling.py
+++ b/Tests/test_parser_schema_coupling.py
@@ -1,0 +1,93 @@
+import json
+from pathlib import Path
+import sys
+
+
+def _ensure_src_on_path() -> Path:
+    repo_root = Path(__file__).resolve().parents[1]
+    src_path = repo_root / "src"
+    if str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+    return repo_root
+
+
+def _load_validator(repo_root: Path):
+    from jsonschema import Draft202012Validator
+
+    schema_path = repo_root / "docs" / "schemas" / "canonical_graph.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    return Draft202012Validator(schema)
+
+
+def test_parser_output_from_text_is_schema_aligned() -> None:
+    repo_root = _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    validator = _load_validator(repo_root)
+    parser = ParserInterface()
+
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Command Processor\nFlow: from=client; to=gateway; protocol=https; data_items=token,request",
+            tables=[],
+        )
+    )
+
+    issues = list(validator.iter_errors(graph.to_dict()))
+    assert issues == []
+
+
+def test_parser_output_from_structured_tables_is_schema_aligned() -> None:
+    repo_root = _ensure_src_on_path()
+
+    from threat_modeler.parsing import ParserInput, ParserInterface
+
+    validator = _load_validator(repo_root)
+    parser = ParserInterface()
+
+    graph = parser.normalize(
+        ParserInput(
+            raw_text="Avionics Node",
+            tables=[
+                {
+                    "schema": "subsystems",
+                    "rows": [
+                        {
+                            "subsystem": "Control Plane",
+                            "subsystem_id": "subsystem_control_plane",
+                            "description": "Control and policy processing",
+                        }
+                    ],
+                },
+                {
+                    "schema": "components",
+                    "rows": [
+                        {
+                            "component": "Policy Engine",
+                            "component_id": "component_policy_engine",
+                            "parent_subsystem": "subsystem_control_plane",
+                            "hardware": "vm",
+                            "software_modules": ["policy", "rules"],
+                            "description": "Policy evaluation",
+                        }
+                    ],
+                },
+                {
+                    "schema": "flows",
+                    "rows": [
+                        {
+                            "from_node": "component_policy_engine",
+                            "to_node": "component_command_dispatch",
+                            "protocol": "grpc",
+                            "data_items": ["policy_decision"],
+                            "trust_boundary_name": "control_network",
+                        }
+                    ],
+                },
+            ],
+        )
+    )
+
+    issues = list(validator.iter_errors(graph.to_dict()))
+    assert issues == []

--- a/planning/work_items/Issue_Parser_Normalization.md
+++ b/planning/work_items/Issue_Parser_Normalization.md
@@ -1,0 +1,76 @@
+# Issue Draft: Implement Parser Normalization to Canonical Graph
+
+## Title
+
+Implement parser normalization from raw inputs to typed canonical graph
+
+## Problem Statement
+
+The current parser seam in `src/threat_modeler/parsing/input_normalizer.py` returns a placeholder dictionary that does not produce a typed `CanonicalThreatModelGraph`. This blocks reliable stage-1 ingestion, weakens schema contract continuity, and prevents realistic end-to-end pipeline behavior.
+
+## Goal
+
+Implement parser normalization that converts `ParserInput` payloads into a schema-aligned typed `CanonicalThreatModelGraph` artifact suitable for Agent 1 output and downstream validation.
+
+## Scope
+
+In scope:
+
+- Implement normalization logic in `ParserInterface.normalize`
+- Return a typed canonical graph model (or strict schema-aligned payload mapped to the typed model)
+- Derive deterministic placeholder IDs where source IDs are missing
+- Map raw text and table input into initial canonical graph structures
+- Ensure produced artifacts are compatible with schema-backed validation
+- Add focused tests for parser normalization behavior
+
+Out of scope:
+
+- Advanced NLP extraction quality improvements
+- Retrieval integration for parser enrichment
+- Full confidence scoring and policy reasoning
+- HITL persistence changes
+
+## Primary Files Likely Affected
+
+- `src/threat_modeler/parsing/input_normalizer.py`
+- `src/threat_modeler/models/canonical.py`
+- `src/threat_modeler/agents/agent_01_input_normalizer.py`
+- `Tests/` parser-focused tests
+
+## Acceptance Criteria
+
+- Parser normalization produces canonical graph artifacts aligned with `docs/schemas/canonical_graph.schema.json`.
+- Output can be consumed by existing orchestrator and validation seams without compatibility hacks.
+- Deterministic IDs are generated for required entities when source data omits IDs.
+- Normalization supports both raw text-only and table-inclusive inputs.
+- Tests cover successful normalization and malformed input handling.
+
+## Requirement Linkage
+
+- PRJ-001
+- PRJ-002
+- PRJ-004
+- CMP-A01-001
+- CMP-A01-002
+- CMP-A01-003
+- INT-001
+- INT-002
+- INT-003
+
+## Verification Approach
+
+- Unit tests for parser input-to-canonical output mapping
+- Validation check against schema-backed validator
+- Inspection of generated IDs and required-field population
+
+## Risks and Notes
+
+- Parser output shape must stay aligned with schema-backed validation to avoid hidden contract drift.
+- Deterministic ID rules should be documented and stable for rerun consistency.
+- Scope should prioritize correctness and contract compliance over extraction sophistication.
+
+## Definition of Done
+
+- Parser normalization produces schema-aligned canonical artifacts.
+- Tests cover key normalization paths and error handling.
+- Integration with existing Agent 1 and validator seams remains stable.

--- a/src/threat_modeler/agents/agent_01_input_normalizer.py
+++ b/src/threat_modeler/agents/agent_01_input_normalizer.py
@@ -1,5 +1,5 @@
 from .base import FrameworkAgent
-from ..models import build_placeholder_graph
+from ..parsing import ParserInput, ParserInterface
 
 
 class Agent01InputNormalizer(FrameworkAgent):
@@ -9,7 +9,9 @@ class Agent01InputNormalizer(FrameworkAgent):
             display_name="Input Normalizer and Graph Builder",
             next_stage_id="agent_02",
         )
+        self.parser = ParserInterface()
 
     def _apply_placeholder_behavior(self, state):
         if state.canonical_graph is None:
-            state.canonical_graph = build_placeholder_graph()
+            payload = ParserInput(raw_text=state.raw_text, tables=state.tables)
+            state.canonical_graph = self.parser.normalize(payload)

--- a/src/threat_modeler/models/canonical.py
+++ b/src/threat_modeler/models/canonical.py
@@ -7,7 +7,6 @@ from dataclasses import asdict, dataclass, field
 class GraphMetadata:
     generation_timestamp: str = "placeholder"
     model_level: str = "system"
-    status: str = "placeholder"
 
 
 @dataclass

--- a/src/threat_modeler/parsing/input_normalizer.py
+++ b/src/threat_modeler/parsing/input_normalizer.py
@@ -1,7 +1,17 @@
 """Parsing interfaces for architecture text and table inputs."""
 
 from dataclasses import dataclass, field
+import re
 from typing import Any
+
+from ..models.canonical import (
+    CanonicalThreatModelGraph,
+    Component,
+    DataFlow,
+    GraphMetadata,
+    Subsystem,
+    SystemContext,
+)
 
 
 @dataclass
@@ -11,10 +21,154 @@ class ParserInput:
 
 
 class ParserInterface:
-    def normalize(self, payload: ParserInput) -> dict[str, Any]:
-        # TODO: Parse architecture text and tables into canonical graph form.
-        return {
-            "metadata": {"status": "parsed_placeholder"},
-            "raw_text_present": bool(payload.raw_text),
-            "table_count": len(payload.tables),
-        }
+    def normalize(self, payload: ParserInput) -> CanonicalThreatModelGraph:
+        text_lines = [line.strip() for line in payload.raw_text.splitlines() if line.strip()]
+        system_name = text_lines[0] if text_lines else "Parsed System"
+        system_description = " ".join(text_lines[1:3]) if len(text_lines) > 1 else "Parsed from raw architecture input."
+
+        default_subsystem = Subsystem(
+            id="subsystem_core",
+            name="Core Subsystem",
+            description="Default subsystem created by parser normalization.",
+            parent_system=system_name,
+        )
+
+        components = self._components_from_tables(payload.tables)
+        if not components:
+            components = [
+                Component(
+                    id="component_primary",
+                    name="Primary Component",
+                    parent_subsystem=default_subsystem.id,
+                    hardware="unknown",
+                    software_modules=[],
+                    description="Default component created by parser normalization.",
+                )
+            ]
+
+        data_flows = self._flows_from_text(text_lines)
+        data_flows.extend(self._flows_from_tables(payload.tables))
+        if not data_flows:
+            data_flows = [
+                DataFlow(
+                    id="df_input_to_primary",
+                    from_node="user.input",
+                    to_node=components[0].id,
+                    protocol="internal",
+                    data_items=["raw_text", "tables"],
+                )
+            ]
+
+        return CanonicalThreatModelGraph(
+            metadata=GraphMetadata(status="parsed", model_level="system"),
+            system=SystemContext(
+                name=system_name,
+                description=system_description,
+                mission_criticality="undetermined",
+                safety_criticality="undetermined",
+            ),
+            subsystems=[default_subsystem],
+            components=components,
+            data_flows=data_flows,
+        )
+
+    def _components_from_tables(self, tables: list[dict[str, Any]]) -> list[Component]:
+        components: list[Component] = []
+        for index, row in enumerate(tables, start=1):
+            name = self._first_str(row, ["component", "component_name", "name"])
+            if not name:
+                continue
+
+            component_id = self._first_str(row, ["component_id", "id"]) or self._deterministic_id("component", name, index)
+            parent_subsystem = self._first_str(row, ["parent_subsystem", "subsystem_id"]) or "subsystem_core"
+            hardware = self._first_str(row, ["hardware", "platform"]) or "unknown"
+            description = self._first_str(row, ["description", "notes"]) or "Parsed from table input."
+            software_modules = self._extract_software_modules(row)
+
+            components.append(
+                Component(
+                    id=component_id,
+                    name=name,
+                    parent_subsystem=parent_subsystem,
+                    hardware=hardware,
+                    software_modules=software_modules,
+                    description=description,
+                )
+            )
+        return components
+
+    def _flows_from_text(self, text_lines: list[str]) -> list[DataFlow]:
+        flows: list[DataFlow] = []
+        pattern = re.compile(r"^(?P<from>[^-]+)->(?P<to>[^:]+)(?::(?P<protocol>.+))?$")
+        for index, line in enumerate(text_lines, start=1):
+            match = pattern.match(line.replace(" ", ""))
+            if not match:
+                continue
+
+            from_node = match.group("from")
+            to_node = match.group("to")
+            protocol = match.group("protocol") or "unknown"
+            flow_id = self._deterministic_id("df", f"{from_node}-{to_node}", index)
+            flows.append(
+                DataFlow(
+                    id=flow_id,
+                    from_node=from_node,
+                    to_node=to_node,
+                    protocol=protocol,
+                    data_items=["parsed_text"],
+                )
+            )
+        return flows
+
+    def _flows_from_tables(self, tables: list[dict[str, Any]]) -> list[DataFlow]:
+        flows: list[DataFlow] = []
+        for index, row in enumerate(tables, start=1):
+            from_node = self._first_str(row, ["from_node", "source", "from"])
+            to_node = self._first_str(row, ["to_node", "target", "to"])
+            if not from_node or not to_node:
+                continue
+
+            flow_id = self._first_str(row, ["flow_id", "id"]) or self._deterministic_id("df", f"{from_node}-{to_node}", index)
+            protocol = self._first_str(row, ["protocol", "transport"]) or "unknown"
+            data_items = self._split_list(self._first_str(row, ["data_items", "data", "payload"]))
+
+            flows.append(
+                DataFlow(
+                    id=flow_id,
+                    from_node=from_node,
+                    to_node=to_node,
+                    protocol=protocol,
+                    data_items=data_items,
+                )
+            )
+        return flows
+
+    @staticmethod
+    def _first_str(row: dict[str, Any], keys: list[str]) -> str:
+        for key in keys:
+            value = row.get(key)
+            if isinstance(value, str):
+                normalized = value.strip()
+                if normalized:
+                    return normalized
+        return ""
+
+    @staticmethod
+    def _split_list(value: str) -> list[str]:
+        if not value:
+            return []
+        return [part.strip() for part in value.split(",") if part.strip()]
+
+    def _extract_software_modules(self, row: dict[str, Any]) -> list[str]:
+        modules_value = row.get("software_modules") or row.get("software") or row.get("modules")
+        if isinstance(modules_value, list):
+            return [str(module).strip() for module in modules_value if str(module).strip()]
+        if isinstance(modules_value, str):
+            return self._split_list(modules_value)
+        return []
+
+    def _deterministic_id(self, prefix: str, source: str, index: int) -> str:
+        slug = re.sub(r"[^a-z0-9]+", "_", source.lower()).strip("_")
+        if not slug:
+            slug = "item"
+        return f"{prefix}_{slug}_{index}"

--- a/src/threat_modeler/parsing/input_normalizer.py
+++ b/src/threat_modeler/parsing/input_normalizer.py
@@ -25,21 +25,26 @@ class ParserInterface:
         text_lines = [line.strip() for line in payload.raw_text.splitlines() if line.strip()]
         system_name = text_lines[0] if text_lines else "Parsed System"
         system_description = " ".join(text_lines[1:3]) if len(text_lines) > 1 else "Parsed from raw architecture input."
+        normalized_rows = self._normalized_rows(payload.tables)
 
-        default_subsystem = Subsystem(
-            id="subsystem_core",
-            name="Core Subsystem",
-            description="Default subsystem created by parser normalization.",
-            parent_system=system_name,
-        )
+        subsystems = self._subsystems_from_tables(normalized_rows, system_name)
+        if not subsystems:
+            subsystems = [
+                Subsystem(
+                    id="subsystem_core",
+                    name="Core Subsystem",
+                    description="Default subsystem created by parser normalization.",
+                    parent_system=system_name,
+                )
+            ]
 
-        components = self._components_from_tables(payload.tables)
+        components = self._components_from_tables(normalized_rows, default_subsystem_id=subsystems[0].id)
         if not components:
             components = [
                 Component(
                     id="component_primary",
                     name="Primary Component",
-                    parent_subsystem=default_subsystem.id,
+                    parent_subsystem=subsystems[0].id,
                     hardware="unknown",
                     software_modules=[],
                     description="Default component created by parser normalization.",
@@ -47,7 +52,7 @@ class ParserInterface:
             ]
 
         data_flows = self._flows_from_text(text_lines)
-        data_flows.extend(self._flows_from_tables(payload.tables))
+        data_flows.extend(self._flows_from_tables(normalized_rows))
         if not data_flows:
             data_flows = [
                 DataFlow(
@@ -60,27 +65,65 @@ class ParserInterface:
             ]
 
         return CanonicalThreatModelGraph(
-            metadata=GraphMetadata(status="parsed", model_level="system"),
+            metadata=GraphMetadata(model_level="system"),
             system=SystemContext(
                 name=system_name,
                 description=system_description,
                 mission_criticality="undetermined",
                 safety_criticality="undetermined",
             ),
-            subsystems=[default_subsystem],
+            subsystems=subsystems,
             components=components,
             data_flows=data_flows,
         )
 
-    def _components_from_tables(self, tables: list[dict[str, Any]]) -> list[Component]:
-        components: list[Component] = []
+    def _subsystems_from_tables(self, tables: list[dict[str, Any]], system_name: str) -> list[Subsystem]:
+        subsystems: list[Subsystem] = []
+        seen_ids: set[str] = set()
+
         for index, row in enumerate(tables, start=1):
+            row_schema = self._row_schema(row)
+            if row_schema and row_schema not in {"subsystem", "subsystems"}:
+                continue
+
+            subsystem_name = self._first_str(row, ["subsystem", "subsystem_name", "name"])
+            if not subsystem_name:
+                continue
+
+            subsystem_id = self._first_str(row, ["subsystem_id", "id"]) or self._deterministic_id("subsystem", subsystem_name, index)
+            if subsystem_id in seen_ids:
+                continue
+
+            seen_ids.add(subsystem_id)
+            subsystems.append(
+                Subsystem(
+                    id=subsystem_id,
+                    name=subsystem_name,
+                    description=self._first_str(row, ["description", "notes"]) or "Parsed from table input.",
+                    parent_system=self._first_str(row, ["parent_system", "system"]) or system_name,
+                )
+            )
+
+        return subsystems
+
+    def _components_from_tables(self, tables: list[dict[str, Any]], *, default_subsystem_id: str) -> list[Component]:
+        components: list[Component] = []
+        seen_ids: set[str] = set()
+        for index, row in enumerate(tables, start=1):
+            row_schema = self._row_schema(row)
+            if row_schema and row_schema not in {"component", "components"}:
+                continue
+
             name = self._first_str(row, ["component", "component_name", "name"])
             if not name:
                 continue
 
             component_id = self._first_str(row, ["component_id", "id"]) or self._deterministic_id("component", name, index)
-            parent_subsystem = self._first_str(row, ["parent_subsystem", "subsystem_id"]) or "subsystem_core"
+            if component_id in seen_ids:
+                continue
+
+            seen_ids.add(component_id)
+            parent_subsystem = self._first_str(row, ["parent_subsystem", "subsystem_id"]) or default_subsystem_id
             hardware = self._first_str(row, ["hardware", "platform"]) or "unknown"
             description = self._first_str(row, ["description", "notes"]) or "Parsed from table input."
             software_modules = self._extract_software_modules(row)
@@ -99,38 +142,69 @@ class ParserInterface:
 
     def _flows_from_text(self, text_lines: list[str]) -> list[DataFlow]:
         flows: list[DataFlow] = []
-        pattern = re.compile(r"^(?P<from>[^-]+)->(?P<to>[^:]+)(?::(?P<protocol>.+))?$")
+        pattern = re.compile(r"^(?P<from>[^-]+)->(?P<to>[^:\[]+)(?::(?P<protocol>[^\[]+))?(?:\[(?P<data_items>[^\]]+)\])?$")
         for index, line in enumerate(text_lines, start=1):
-            match = pattern.match(line.replace(" ", ""))
-            if not match:
+            lower_line = line.lower()
+            if lower_line.startswith("flow:"):
+                fields = self._parse_structured_fields(line.split(":", maxsplit=1)[1])
+                from_node = fields.get("from") or fields.get("source")
+                to_node = fields.get("to") or fields.get("target")
+                if from_node and to_node:
+                    flow_id = fields.get("id") or self._deterministic_id("df", f"{from_node}-{to_node}", index)
+                    trust_boundary_name = fields.get("trust_boundary") or fields.get("boundary") or ""
+                    flows.append(
+                        DataFlow(
+                            id=flow_id,
+                            from_node=from_node,
+                            to_node=to_node,
+                            protocol=fields.get("protocol", "unknown"),
+                            data_items=self._split_list(fields.get("data_items") or fields.get("data") or ""),
+                            trust_boundary_crossing=bool(trust_boundary_name),
+                            trust_boundary_name=trust_boundary_name,
+                        )
+                    )
                 continue
 
-            from_node = match.group("from")
-            to_node = match.group("to")
-            protocol = match.group("protocol") or "unknown"
-            flow_id = self._deterministic_id("df", f"{from_node}-{to_node}", index)
-            flows.append(
-                DataFlow(
-                    id=flow_id,
-                    from_node=from_node,
-                    to_node=to_node,
-                    protocol=protocol,
-                    data_items=["parsed_text"],
+            compact = line.replace(" ", "")
+            match = pattern.match(compact)
+            if match:
+                from_node = match.group("from")
+                to_node = match.group("to")
+                protocol = match.group("protocol") or "unknown"
+                flow_id = self._deterministic_id("df", f"{from_node}-{to_node}", index)
+                items = self._split_list(match.group("data_items") or "") or ["parsed_text"]
+                flows.append(
+                    DataFlow(
+                        id=flow_id,
+                        from_node=from_node,
+                        to_node=to_node,
+                        protocol=protocol,
+                        data_items=items,
+                    )
                 )
-            )
         return flows
 
     def _flows_from_tables(self, tables: list[dict[str, Any]]) -> list[DataFlow]:
         flows: list[DataFlow] = []
+        seen_ids: set[str] = set()
         for index, row in enumerate(tables, start=1):
+            row_schema = self._row_schema(row)
+            if row_schema and row_schema not in {"flow", "flows", "data_flow", "data_flows"}:
+                continue
+
             from_node = self._first_str(row, ["from_node", "source", "from"])
             to_node = self._first_str(row, ["to_node", "target", "to"])
             if not from_node or not to_node:
                 continue
 
             flow_id = self._first_str(row, ["flow_id", "id"]) or self._deterministic_id("df", f"{from_node}-{to_node}", index)
+            if flow_id in seen_ids:
+                continue
+
+            seen_ids.add(flow_id)
             protocol = self._first_str(row, ["protocol", "transport"]) or "unknown"
-            data_items = self._split_list(self._first_str(row, ["data_items", "data", "payload"]))
+            data_items = self._extract_data_items(row)
+            trust_boundary_name = self._first_str(row, ["trust_boundary_name", "trust_boundary", "boundary"])
 
             flows.append(
                 DataFlow(
@@ -139,9 +213,50 @@ class ParserInterface:
                     to_node=to_node,
                     protocol=protocol,
                     data_items=data_items,
+                    trust_boundary_crossing=bool(trust_boundary_name),
+                    trust_boundary_name=trust_boundary_name,
                 )
             )
         return flows
+
+    def _normalized_rows(self, tables: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for table in tables:
+            nested_rows = table.get("rows")
+            if isinstance(nested_rows, list):
+                schema_name = self._first_str(table, ["schema", "kind", "type", "table"])
+                for nested_row in nested_rows:
+                    if not isinstance(nested_row, dict):
+                        continue
+                    enriched_row = dict(nested_row)
+                    if schema_name and "__schema" not in enriched_row:
+                        enriched_row["__schema"] = schema_name
+                    rows.append(enriched_row)
+                continue
+
+            rows.append(table)
+        return rows
+
+    def _row_schema(self, row: dict[str, Any]) -> str:
+        return self._first_str(row, ["__schema", "schema", "kind", "type"]).lower()
+
+    def _extract_data_items(self, row: dict[str, Any]) -> list[str]:
+        direct_list = row.get("data_items") or row.get("data") or row.get("payload")
+        if isinstance(direct_list, list):
+            return [str(item).strip() for item in direct_list if str(item).strip()]
+        return self._split_list(self._first_str(row, ["data_items", "data", "payload"]))
+
+    def _parse_structured_fields(self, text: str) -> dict[str, str]:
+        fields: dict[str, str] = {}
+        for part in text.split(";"):
+            if "=" not in part:
+                continue
+            key, value = part.split("=", maxsplit=1)
+            normalized_key = key.strip().lower()
+            normalized_value = value.strip()
+            if normalized_key and normalized_value:
+                fields[normalized_key] = normalized_value
+        return fields
 
     @staticmethod
     def _first_str(row: dict[str, Any], keys: list[str]) -> str:


### PR DESCRIPTION
## Summary
This PR introduces parser normalization on `feature/parser-normalization` as a stacked follow-up to the framework scaffold.

### Included now
- First implementation slice (already pushed):
  - Agent 01 uses parser normalization output instead of placeholder graph builder.
  - Parser returns typed canonical graph output.
  - Baseline parser tests were added.
- Second implementation slice (to be added in this PR):
  - Subsystem extraction from structured table/text inputs.
  - Richer flow parsing from structured text/table schemas.
  - Additional parser tests for those pathways.

## Why this target branch
This branch is currently stacked on `feature/framework-source-skeleton`.
After the scaffold PR merges, this PR can be retargeted/rebased to `main`.

## Notes on validation coupling
Schema-validation coupling tests depend on the schema-backed validator branch state. Those tests will be added in the aligned follow-up once validation branch history is rebased/retargeted.